### PR TITLE
Fix GitHub workflows for enterprise fork - update chart metadata and registry publishing

### DIFF
--- a/.github/workflows/Alethic.Auth0.Operator.yml
+++ b/.github/workflows/Alethic.Auth0.Operator.yml
@@ -104,6 +104,9 @@ jobs:
     needs:
     - build
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Checkout Source
       uses: actions/checkout@v4

--- a/charts/auth0-operator/Chart.yaml
+++ b/charts/auth0-operator/Chart.yaml
@@ -6,9 +6,9 @@ version: 0.0.0
 appVersion: "0.0.0"
 keywords:
   - auth0
-home: https://github.com/alethic/auth0-operator
+home: https://github.com/seatgeek/auth0-operator
 sources:
-  - https://github.com/alethic/auth0-operator
+  - https://github.com/seatgeek/auth0-operator
 maintainers:
-  - name: Jerome Haltom
-    email: jhaltom@alethic.solutions
+  - name: SeatGeek Infrastructure Team
+    email: infrastructure@seatgeek.com


### PR DESCRIPTION
Fix GitHub workflows for enterprise fork - update chart metadata and registry publishing