### PR TITLE
Restore Android sha256CertFingerprints mapping for Client

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3ClientControllerMappingTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3ClientControllerMappingTests.cs
@@ -298,6 +298,7 @@ namespace Alethic.Auth0.Operator.Tests
                 Android = new ClientMobileAndroid
                 {
                     AppPackageName = "com.example.android",
+                    Sha256CertFingerprints = ["AA:BB:CC", "DD:EE:FF"],
                 },
             };
 
@@ -309,6 +310,7 @@ namespace Alethic.Auth0.Operator.Tests
             Assert.AreEqual("TEAM123", result.Ios.TeamId);
             Assert.IsNotNull(result.Android);
             Assert.AreEqual("com.example.android", result.Android.AppPackageName);
+            CollectionAssert.AreEqual(new[] { "AA:BB:CC", "DD:EE:FF" }, result.Android.Sha256CertFingerprints);
         }
 
         [TestMethod]
@@ -373,6 +375,34 @@ namespace Alethic.Auth0.Operator.Tests
                 request.OidcLogout.BackchannelLogoutInitiators.SelectedInitiators?.Select(static i => i.Value).ToArray());
             Assert.IsTrue(request.OidcLogout.BackchannelLogoutSessionMetadata.IsDefined);
             Assert.AreEqual(true, request.OidcLogout.BackchannelLogoutSessionMetadata.Value?.Include);
+        }
+
+        [TestMethod]
+        public void ApplyToApi_Create_MapsAndroidMobile()
+        {
+            var conf = new V2alpha3ClientConf
+            {
+                Name = "my-app",
+                ApplicationType = V2alpha3ClientAppTypeEnum.Native,
+                Mobile = new V2alpha3ClientMobile
+                {
+                    Android = new V2alpha3ClientMobileAndroid
+                    {
+                        AppPackageName = "com.example.android",
+                        Sha256CertFingerprints = ["AA:BB:CC", "DD:EE:FF"],
+                    },
+                },
+            };
+
+            var request = new CreateClientRequestContent { Name = conf.Name! };
+            V2alpha3ClientController.ApplyToApi(conf, request);
+
+            Assert.IsNotNull(request.Mobile);
+            Assert.IsNotNull(request.Mobile.Android);
+            Assert.AreEqual("com.example.android", request.Mobile.Android.AppPackageName);
+            CollectionAssert.AreEqual(
+                new[] { "AA:BB:CC", "DD:EE:FF" },
+                request.Mobile.Android.Sha256CertFingerprints?.ToArray());
         }
 
         [TestMethod]
@@ -684,6 +714,14 @@ namespace Alethic.Auth0.Operator.Tests
                                 SelectedInitiators = [V1ClientLogoutInitiators.RpLogout],
                             },
                         },
+                        Mobile = new V1ClientMobile
+                        {
+                            Android = new V1ClientMobile.MobileAndroid
+                            {
+                                AppPackageName = "com.example.android",
+                                KeystoreHash = "AA:BB:CC",
+                            },
+                        },
                     },
                 },
                 Status =
@@ -713,6 +751,9 @@ namespace Alethic.Auth0.Operator.Tests
             CollectionAssert.AreEqual(new[] { "https://example.com/logout" }, result.Spec.Conf.OidcLogout.BackchannelLogoutUrls);
             Assert.AreEqual(V2alpha3ClientOidcBackchannelLogoutInitiatorsModeEnum.Custom, result.Spec.Conf.OidcLogout.BackchannelLogoutInitiators?.Mode);
             CollectionAssert.AreEqual(new[] { V2alpha3ClientOidcBackchannelLogoutInitiatorsEnum.RpLogout }, result.Spec.Conf.OidcLogout.BackchannelLogoutInitiators?.SelectedInitiators);
+            Assert.IsNotNull(result.Spec.Conf.Mobile?.Android);
+            Assert.AreEqual("com.example.android", result.Spec.Conf.Mobile!.Android!.AppPackageName);
+            CollectionAssert.AreEqual(new[] { "AA:BB:CC" }, result.Spec.Conf.Mobile.Android.Sha256CertFingerprints);
         }
 
         [TestMethod]
@@ -761,6 +802,14 @@ namespace Alethic.Auth0.Operator.Tests
                             Pub = "pub",
                             Subject = "subject",
                         },
+                        Mobile = new V2alpha3ClientMobile
+                        {
+                            Android = new V2alpha3ClientMobileAndroid
+                            {
+                                AppPackageName = "com.example.android",
+                                Sha256CertFingerprints = ["AA:BB:CC", "DD:EE:FF"],
+                            },
+                        },
                     },
                 },
                 Status =
@@ -794,6 +843,9 @@ namespace Alethic.Auth0.Operator.Tests
             Assert.AreEqual("cert", result.Spec.Conf.EncryptionKey.Certificate);
             Assert.AreEqual("pub", result.Spec.Conf.EncryptionKey.PublicKey);
             Assert.AreEqual("subject", result.Spec.Conf.EncryptionKey.Subject);
+            Assert.IsNotNull(result.Spec.Conf.Mobile?.Android);
+            Assert.AreEqual("com.example.android", result.Spec.Conf.Mobile!.Android!.AppPackageName);
+            Assert.AreEqual("AA:BB:CC", result.Spec.Conf.Mobile.Android.KeystoreHash);
         }
 
         static V2alpha3ClientEntity InvokeConvert(V1Client source)

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ClientController.cs
@@ -213,12 +213,13 @@ namespace Alethic.Auth0.Operator.Controllers
         {
             if (source is null)
                 return null;
-            if (source.AppPackageName is null)
+            if (source.AppPackageName is null && source.Sha256CertFingerprints is null)
                 return null;
 
             return new()
             {
                 AppPackageName = source.AppPackageName,
+                Sha256CertFingerprints = source.Sha256CertFingerprints?.ToArray(),
             };
         }
 
@@ -1006,6 +1007,9 @@ namespace Alethic.Auth0.Operator.Controllers
         {
             if (source.AppPackageName is { } appPackageName)
                 target.AppPackageName = appPackageName;
+
+            if (source.Sha256CertFingerprints is { } sha256CertFingerprints)
+                target.Sha256CertFingerprints = sha256CertFingerprints;
         }
 
         internal static void ApplyToApi(V2alpha3ClientMobileiOs source, ClientMobileiOs target)
@@ -1019,7 +1023,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static void ApplyToApi(V2alpha3ClientMobile source, ClientMobile target)
         {
-            if (source.Android is { } android && android.AppPackageName is not null)
+            if (source.Android is { } android && (android.AppPackageName is not null || android.Sha256CertFingerprints is not null))
                 ApplyToApi(android, target.Android ??= new ClientMobileAndroid());
 
             if (source.Ios is { } ios && (ios.AppBundleIdentifier is not null || ios.TeamId is not null))

--- a/src/Alethic.Auth0.Operator/Converters/ClientConverter.cs
+++ b/src/Alethic.Auth0.Operator/Converters/ClientConverter.cs
@@ -100,7 +100,7 @@ namespace Alethic.Auth0.Operator.Converters
                     DefaultOrganization = source.DefaultOrganization is { } defaultOrganization ? ConvertWithAuth0<V1ClientDefaultOrganization, ClientDefaultOrganization, V2alpha3ClientDefaultOrganization>(defaultOrganization, V2alpha3ClientController.FromApi) : null,
                     EncryptionKey = source.EncryptionKey is { } encryptionKey ? ConvertWithAuth0<V1ClientEncryptionKey, ClientEncryptionKey, V2alpha3ClientEncryptionKey>(encryptionKey, V2alpha3ClientController.FromApi) : null,
                     JwtConfiguration = source.JwtConfiguration is { } jwtConfiguration ? ConvertWithAuth0<V1ClientJwtConfiguration, ClientJwtConfiguration, V2alpha3ClientJwtConfiguration>(jwtConfiguration, V2alpha3ClientController.FromApi) : null,
-                    Mobile = source.Mobile is { } mobile ? ConvertWithAuth0<V1ClientMobile, ClientMobile, V2alpha3ClientMobile>(mobile, V2alpha3ClientController.FromApi) : null,
+                    Mobile = ConvertMobile(source.Mobile),
                     OidcLogout = source.OidcLogout is { } oidcLogout ? ConvertWithAuth0<V1ClientOidcLogoutConfig, ClientOidcBackchannelLogoutSettings, V2alpha3ClientOidcBackchannelLogoutSettings>(oidcLogout, V2alpha3ClientController.FromApi) : null,
                     OrganizationRequireBehavior = source.OrganizationRequireBehavior is { } organizationRequireBehavior ? ConvertOrganizationRequireBehavior(organizationRequireBehavior) : null,
                     OrganizationUsage = source.OrganizationUsage is { } organizationUsage ? ConvertOrganizationUsage(organizationUsage) : null,
@@ -146,7 +146,7 @@ namespace Alethic.Auth0.Operator.Converters
                     DefaultOrganization = source.DefaultOrganization is { } defaultOrganization ? RevertWithAuth0<V2alpha3ClientDefaultOrganization, ClientDefaultOrganization, V1ClientDefaultOrganization>(defaultOrganization, ToApi) : null,
                     EncryptionKey = source.EncryptionKey is { } encryptionKey ? RevertWithAuth0<V2alpha3ClientEncryptionKey, ClientEncryptionKey, V1ClientEncryptionKey>(encryptionKey, ToApi) : null,
                     JwtConfiguration = source.JwtConfiguration is { } jwtConfiguration ? RevertWithAuth0<V2alpha3ClientJwtConfiguration, ClientJwtConfiguration, V1ClientJwtConfiguration>(jwtConfiguration, ToApi) : null,
-                    Mobile = source.Mobile is { } mobile ? RevertWithAuth0<V2alpha3ClientMobile, ClientMobile, V1ClientMobile>(mobile, ToApi) : null,
+                    Mobile = RevertMobile(source.Mobile),
                     OidcLogout = source.OidcLogout is { } oidcLogout ? RevertWithAuth0<V2alpha3ClientOidcBackchannelLogoutSettings, ClientOidcBackchannelLogoutSettings, V1ClientOidcLogoutConfig>(oidcLogout, ToApi) : null,
                     OrganizationRequireBehavior = source.OrganizationRequireBehavior is { } organizationRequireBehavior ? RevertOrganizationRequireBehavior(organizationRequireBehavior) : null,
                     OrganizationUsage = source.OrganizationUsage is { } organizationUsage ? RevertOrganizationUsage(organizationUsage) : null,
@@ -309,11 +309,79 @@ namespace Alethic.Auth0.Operator.Converters
                 return result;
             }
 
-            static ClientMobile ToApi(V2alpha3ClientMobile source)
+            // Mobile is mapped by hand rather than through the Auth0 SDK round-trip: v1 stores the
+            // Android signing hash as the legacy scalar `keystore_hash`, whereas v2alpha3 (and the
+            // Auth0 8.x SDK) model it as the `sha256CertFingerprints` array, so the shapes differ.
+            static V2alpha3ClientMobile? ConvertMobile(V1ClientMobile? source)
             {
-                var result = new ClientMobile();
-                V2alpha3ClientController.ApplyToApi(source, result);
-                return result;
+                if (source is null)
+                    return null;
+
+                return new V2alpha3ClientMobile
+                {
+                    Android = ConvertMobileAndroid(source.Android),
+                    Ios = ConvertMobileIos(source.Ios),
+                };
+            }
+
+            static V2alpha3ClientMobileAndroid? ConvertMobileAndroid(V1ClientMobile.MobileAndroid? source)
+            {
+                if (source is null)
+                    return null;
+
+                return new V2alpha3ClientMobileAndroid
+                {
+                    AppPackageName = source.AppPackageName,
+                    Sha256CertFingerprints = source.KeystoreHash is { } keystoreHash ? [keystoreHash] : null,
+                };
+            }
+
+            static V2alpha3ClientMobileiOs? ConvertMobileIos(V1ClientMobile.MobileIos? source)
+            {
+                if (source is null)
+                    return null;
+
+                return new V2alpha3ClientMobileiOs
+                {
+                    AppBundleIdentifier = source.AppBundleIdentifier,
+                    TeamId = source.TeamId,
+                };
+            }
+
+            static V1ClientMobile? RevertMobile(V2alpha3ClientMobile? source)
+            {
+                if (source is null)
+                    return null;
+
+                return new V1ClientMobile
+                {
+                    Android = RevertMobileAndroid(source.Android),
+                    Ios = RevertMobileIos(source.Ios),
+                };
+            }
+
+            static V1ClientMobile.MobileAndroid? RevertMobileAndroid(V2alpha3ClientMobileAndroid? source)
+            {
+                if (source is null)
+                    return null;
+
+                return new V1ClientMobile.MobileAndroid
+                {
+                    AppPackageName = source.AppPackageName,
+                    KeystoreHash = source.Sha256CertFingerprints is { Length: > 0 } fingerprints ? fingerprints[0] : null,
+                };
+            }
+
+            static V1ClientMobile.MobileIos? RevertMobileIos(V2alpha3ClientMobileiOs? source)
+            {
+                if (source is null)
+                    return null;
+
+                return new V1ClientMobile.MobileIos
+                {
+                    AppBundleIdentifier = source.AppBundleIdentifier,
+                    TeamId = source.TeamId,
+                };
             }
 
             static ClientOidcBackchannelLogoutSettings ToApi(V2alpha3ClientOidcBackchannelLogoutSettings source)


### PR DESCRIPTION
## What

Restore the Android cert-fingerprint mapping on the `Client` resource so it round-trips to Auth0 and survives v1 → v2alpha3 conversion.

## Why

The mapping was correct in the original **v1** controller (Auth0 SDK 7.x, field `keystore_hash`) — both `FromApi` and `ApplyToApi` carried it. It was silently dropped in the **v1 → v2alpha1/v2alpha3 controller rewrite**, which coincided with the Auth0 SDK **7 → 8** upgrade that renamed the field `keystore_hash` (scalar) → `sha256CertFingerprints` (array). The rebuilt Android mapper only copied `appPackageName`, so from v2alpha1 onward the fingerprints were dropped in **both** directions and never reached Auth0.

## Changes

- **`V2alpha3ClientController`** — `FromApi(ClientMobileAndroid)` reads `Sha256CertFingerprints` back from Auth0 (and no longer short-circuits when only fingerprints are present); `ApplyToApi(...)` pushes them; the `ClientMobile` guard fires on fingerprints-only too.
- **`ClientConverter` (v1 ↔ v2alpha3)** — hand-written mobile mappers bridge the legacy scalar `keystore_hash` ↔ array `sha256CertFingerprints` (`[0]` on the way back), replacing the JSON round-trip that couldn't (the field name/shape differ). This is what lets an upgrading user's existing **v1** `Client` keep its fingerprint when it's converted to the v2alpha3 storage version.
- **Tests** — extended the existing v1 ↔ v2alpha3 round-trip tests to cover the mobile block.

## Testing

Full suite green (242/242). The v1 `keystore_hash` served CRD field is left untouched (deprecated served version — not re-cased).
