### PR TITLE
Migrate stored objects to the hub storage version at operator startup

### DIFF
--- a/src/Alethic.Auth0.Operator/Program.cs
+++ b/src/Alethic.Auth0.Operator/Program.cs
@@ -21,6 +21,7 @@ namespace Alethic.Auth0.Operator
 
             var operatorOptions = builder.Configuration.GetSection("Auth0:Operator").Get<OperatorOptions>() ?? new OperatorOptions();
             builder.Services.AddKubernetesOperator(s => s.ParallelReconciliation.MaxParallelReconciliations = operatorOptions.Reconciliation.MaxParallelReconciliations).RegisterComponents();
+            builder.Services.AddHostedService<StorageVersionMigrationService>();
             builder.Services.AddSingleton<Auth0HttpClientProvider>();
             builder.Services.AddMemoryCache();
             builder.Services.AddRouting();

--- a/src/Alethic.Auth0.Operator/StorageVersionMigrationService.cs
+++ b/src/Alethic.Auth0.Operator/StorageVersionMigrationService.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Alethic.Auth0.Operator.Models;
+
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+
+using KubeOps.KubernetesClient;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Alethic.Auth0.Operator
+{
+
+    /// <summary>
+    /// Rewrites every operator-owned custom resource at startup so it is persisted in etcd at the current storage
+    /// (hub) version. Objects written under an earlier hub (e.g. a Tenant stored as <c>v2alpha1</c> after the hub
+    /// moved to <c>v2alpha3</c>) otherwise remain stored at that old version indefinitely, and any read at a third
+    /// served version (e.g. <c>v1</c>) then requires a two-hop conversion (stored → hub → requested) that the KubeOps
+    /// conversion webhook does not perform — it routes single-hop only, silently returning zero converted objects.
+    /// The API server surfaces that as <c>conversion webhook ... returned 0 objects, expected 1</c>, breaking every
+    /// consumer that reads at the affected version (kubectl's preferred version, controller informers, Helm/Flux).
+    /// Rewriting the objects at the hub version makes every subsequent conversion single-hop, which is the same
+    /// remedy the Kubernetes storage version migrator applies after a storage version change.
+    /// </summary>
+    /// <remarks>
+    /// The rewrite is a no-op update: listing at the hub version and putting the object back unchanged re-encodes it
+    /// at the storage version. Objects already stored at the hub are byte-identical on write, so the API server skips
+    /// the etcd write entirely — repeated startups cost nothing. Rewritten objects do emit a Modified watch event, but
+    /// the update never changes <c>metadata.generation</c>, so the watcher's generation-based dedup does not schedule
+    /// any additional reconciliation. Migration waits for the application to have started because listing old-stored
+    /// objects at the hub version calls back into this operator's own conversion webhook.
+    /// </remarks>
+    public class StorageVersionMigrationService : BackgroundService
+    {
+
+        /// <summary>
+        /// Maximum attempts to list a kind before giving up. Listing requires the operator's own conversion webhook to
+        /// be reachable from the API server, which lags application start by the readiness probe and endpoint
+        /// propagation, so early attempts are expected to fail.
+        /// </summary>
+        const int MaxListAttempts = 30;
+
+        static readonly TimeSpan ListRetryDelay = TimeSpan.FromSeconds(10);
+
+        readonly IKubernetesClient _kube;
+        readonly IHostApplicationLifetime _lifetime;
+        readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="kube"></param>
+        /// <param name="lifetime"></param>
+        /// <param name="logger"></param>
+        public StorageVersionMigrationService(IKubernetesClient kube, IHostApplicationLifetime lifetime, ILogger<StorageVersionMigrationService> logger)
+        {
+            _kube = kube ?? throw new ArgumentNullException(nameof(kube));
+            _lifetime = lifetime ?? throw new ArgumentNullException(nameof(lifetime));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc />
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // hosted services begin before the web host serves requests; wait for full application start so the
+            // conversion webhook (served by this process) can satisfy the hub-version list calls below
+            var started = new TaskCompletionSource();
+            await using var registration = _lifetime.ApplicationStarted.Register(() => started.TrySetResult());
+            if (_lifetime.ApplicationStarted.IsCancellationRequested)
+                started.TrySetResult();
+
+            await started.Task.WaitAsync(stoppingToken);
+
+            _logger.LogInformation("Beginning storage version migration of Auth0 operator resources.");
+
+            await MigrateAsync<V2alpha3Tenant>(stoppingToken);
+            await MigrateAsync<V2alpha3Client>(stoppingToken);
+            await MigrateAsync<V2alpha3Connection>(stoppingToken);
+            await MigrateAsync<V2alpha3ResourceServer>(stoppingToken);
+            await MigrateAsync<V2alpha3ClientGrant>(stoppingToken);
+            await MigrateAsync<V2alpha3Role>(stoppingToken);
+            await MigrateAsync<V2alpha3BrandingTheme>(stoppingToken);
+            await MigrateAsync<V2alpha3CustomDomain>(stoppingToken);
+            await MigrateAsync<V2alpha3CustomText>(stoppingToken);
+            await MigrateAsync<V2alpha3ConnectionClient>(stoppingToken);
+
+            _logger.LogInformation("Completed storage version migration of Auth0 operator resources.");
+        }
+
+        /// <summary>
+        /// Rewrites all instances of the specified kind at the hub version. Failures are logged and skipped: a missed
+        /// object is simply migrated on the next operator start, and must never prevent the operator from running.
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        async Task MigrateAsync<TEntity>(CancellationToken cancellationToken)
+            where TEntity : IKubernetesObject<V1ObjectMeta>
+        {
+            var list = await ListWithRetryAsync<TEntity>(cancellationToken);
+            if (list is null)
+                return;
+
+            var count = 0;
+
+            foreach (var entity in list)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    await _kube.UpdateAsync(entity, cancellationToken);
+                    count++;
+                }
+                catch (HttpOperationException e) when (e.Response.StatusCode is HttpStatusCode.Conflict or HttpStatusCode.NotFound)
+                {
+                    // a concurrent write has itself re-persisted the object at the storage version, or it is gone
+                    _logger.LogDebug("Skipping storage version rewrite of {Kind} {Namespace}/{Name}: {StatusCode}.", typeof(TEntity).Name, entity.Namespace(), entity.Name(), e.Response.StatusCode);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogWarning(e, "Failed storage version rewrite of {Kind} {Namespace}/{Name}; it will be retried on next startup.", typeof(TEntity).Name, entity.Namespace(), entity.Name());
+                }
+            }
+
+            _logger.LogInformation("Storage version migration rewrote {Count} instance(s) of {Kind}.", count, typeof(TEntity).Name);
+        }
+
+        /// <summary>
+        /// Lists all instances of the specified kind at the hub version, retrying while the operator's conversion
+        /// webhook becomes reachable. Returns <c>null</c> when the list could not be obtained.
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        async Task<System.Collections.Generic.IList<TEntity>?> ListWithRetryAsync<TEntity>(CancellationToken cancellationToken)
+            where TEntity : IKubernetesObject<V1ObjectMeta>
+        {
+            for (var attempt = 1; attempt <= MaxListAttempts; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    return await _kube.ListAsync<TEntity>(cancellationToken: cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    if (attempt == MaxListAttempts)
+                    {
+                        _logger.LogWarning(e, "Failed to list {Kind} for storage version migration after {Attempts} attempts; skipping (it will be retried on next startup).", typeof(TEntity).Name, attempt);
+                        return null;
+                    }
+
+                    _logger.LogDebug(e, "Failed to list {Kind} for storage version migration (attempt {Attempt}/{Attempts}); retrying.", typeof(TEntity).Name, attempt, MaxListAttempts);
+                    await Task.Delay(ListRetryDelay, cancellationToken);
+                }
+            }
+
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Problem

Objects written while an earlier CRD version was the storage version (e.g. a `Tenant` persisted as `v2alpha1` before the hub moved to `v2alpha3`) remain stored at that old version indefinitely. Reading such an object at a third served version — e.g. `v1`, which is kubectl's preferred version for Kinds that serve it — requires a two-hop conversion (stored → hub → requested).

KubeOps' `ConversionWebhook<T>` routes **single-hop only**: it builds `(X → hub)` and `(hub → X)` pairs from the registered converters and **silently skips** any object with no direct match, returning zero converted objects. The API server surfaces this as:

```
Error from server: conversion webhook for kubernetes.auth0.com/v2alpha1, Kind=Tenant returned 0 objects, expected 1
```

Every consumer reading at the affected version breaks (kubectl, controller informers, Helm/Flux), and informers go into a hot retry loop against the webhook (~12 req/s observed).

**Field evidence:** a production cluster with a `v2alpha1`-stored Tenant. The actual broken object was extracted and run through this repo's converter chain locally (`v2alpha1 → v2alpha3 → v1`) — it converts perfectly, proving the converters compose and the gap is purely KubeOps webhook routing.

## Why not fix the routing?

KubeOps' `IEntityConverter<TSource, TEntity>` hard-wires the hub as the target type, so a direct `v2alpha1 → v1` pair converter is not expressible. The webhook also auto-derives a reverse entry for every registered converter, so faking pairs through the non-generic surface produces reverse routes that either crash (invalid cast to the hub type) or mis-deserialize. The routing is effectively sealed; a proper multi-hop fix belongs upstream (issue to follow).

## Fix

A startup hosted service (`StorageVersionMigrationService`) lists every operator Kind at the hub version and writes each object back unchanged, re-encoding it at the current storage version — the same remedy the Kubernetes storage-version-migrator applies after a storage version change. Once rewritten, every conversion is single-hop.

Properties:
- **Idempotent / free when clean**: objects already stored at the hub are byte-identical on write; the API server skips the etcd write, so subsequent startups are no-ops.
- **No reconcile amplification**: rewrites never change `metadata.generation`, so the watcher's generation dedup schedules nothing.
- **Webhook-ready**: waits for `ApplicationStarted` and retries listing (the hub-version list calls back into this operator's own conversion webhook), since endpoint propagation lags startup.
- **Failure-tolerant**: per-object failures are logged and deferred to the next startup; migration can never prevent the operator from running.
- **Self-healing for existing installs**: clusters currently broken by old-stored objects heal automatically on their next operator upgrade/restart, with no manual `kubectl` surgery.

## Testing

- Build clean, all 242 existing tests pass.
- The production-broken Tenant object was validated end-to-end through the converter chain locally.
- Runtime behavior (list → rewrite → conversion recovery) requires a cluster; validated by analysis against the decompiled KubeOps 10.5 webhook/queue implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)