### PR TITLE
Catch Auth0 8.x NotFoundError so missing remote entities self-heal

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3BrandingThemeControllerNotFoundTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3BrandingThemeControllerNotFoundTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Auth0.ManagementApi;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests
+{
+
+    /// <summary>
+    /// Regression coverage for the "not found" exception contract that every controller's Get/Find self-heal
+    /// logic depends on. The Auth0 8.x Management SDK throws <see cref="NotFoundError"/> on a 404 — NOT the
+    /// legacy <c>Auth0.Core.Exceptions.ErrorApiException</c> the controllers used to catch. Because a
+    /// <c>catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)</c> never matched
+    /// <see cref="NotFoundError"/>, a stale/missing remote id (e.g. a BrandingTheme whose Auth0 theme was
+    /// deleted) escaped as an unhandled NotFoundError and the reconcile hard-failed, instead of returning null
+    /// so the reconciler could clear status and recreate. These tests pin the SDK behaviour that makes
+    /// <c>catch (NotFoundError)</c> correct.
+    /// </summary>
+    [TestClass]
+    public class V2alpha3BrandingThemeControllerNotFoundTests
+    {
+
+        /// <summary>
+        /// An <see cref="HttpMessageHandler"/> that always responds with a fixed status code and body, so the
+        /// real generated Management SDK client runs its status-code-to-exception mapping.
+        /// </summary>
+        sealed class StaticResponseHandler : HttpMessageHandler
+        {
+
+            readonly HttpStatusCode _status;
+            readonly string _body;
+
+            public StaticResponseHandler(HttpStatusCode status, string body)
+            {
+                _status = status;
+                _body = body;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                Task.FromResult(new HttpResponseMessage(_status) { Content = new StringContent(_body, Encoding.UTF8, "application/json") });
+
+        }
+
+        static ManagementApiClient CreateClient(HttpStatusCode status, string body) =>
+            new ManagementApiClient("test-token", new ClientOptions
+            {
+                BaseUrl = "https://tenant.example.com/api/v2/",
+                HttpClient = new HttpClient(new StaticResponseHandler(status, body)),
+                MaxRetries = 0,
+            });
+
+        [TestMethod]
+        public async Task GetAsync_on_404_throws_NotFoundError()
+        {
+            var api = CreateClient(HttpStatusCode.NotFound, "{\"statusCode\":404,\"error\":\"Not Found\",\"message\":\"Theme not found\",\"errorCode\":\"inexistent_theme\"}");
+
+            var threwNotFound = false;
+            try
+            {
+                // this is exactly what the controller's Get(...) awaits; on a 404 it must throw NotFoundError so
+                // the controller's catch (NotFoundError) returns null and the reconciler self-heals
+                await api.Branding.Themes.GetAsync("nonexistent-theme-id");
+            }
+            catch (NotFoundError)
+            {
+                threwNotFound = true;
+            }
+
+            Assert.IsTrue(threwNotFound, "a 404 from the 8.x Management SDK must surface as NotFoundError (the type the controllers catch).");
+        }
+
+        [TestMethod]
+        public void NotFoundError_is_a_ManagementApiException_but_not_the_legacy_ErrorApiException()
+        {
+            // ControllerBase's generic handler catches ManagementApiException, so every 8.x API error (including
+            // NotFoundError) is turned into an ApiError event + retry rather than an unhandled crash
+            Assert.IsTrue(
+                typeof(ManagementApiException).IsAssignableFrom(typeof(NotFoundError)),
+                "NotFoundError must be a ManagementApiException so ControllerBase's generic handler catches it.");
+
+            // the original bug: the controllers caught the legacy Auth0.Core ErrorApiException, which NotFoundError
+            // does not derive from, so the NotFound catch never fired
+            var legacyErrorApiException = Type.GetType("Auth0.Core.Exceptions.ErrorApiException, Auth0.Core");
+            if (legacyErrorApiException is not null)
+                Assert.IsFalse(
+                    legacyErrorApiException.IsAssignableFrom(typeof(NotFoundError)),
+                    "NotFoundError must NOT derive from the legacy ErrorApiException; catching ErrorApiException silently misses 404s.");
+        }
+
+    }
+
+}

--- a/src/Alethic.Auth0.Operator/Controllers/ControllerBase.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/ControllerBase.cs
@@ -574,6 +574,27 @@ namespace Alethic.Auth0.Operator.Controllers
                 Logger.LogInformation("Rescheduling reconcilation after {TimeSpan}.", interval);
                 return ReconciliationResult<TEntity>.Failure(entity, e.Message, e, interval);
             }
+            catch (ManagementApiException e)
+            {
+                // the 8.x Auth0 Management SDK surfaces API errors as ManagementApiException subtypes (NotFoundError,
+                // BadRequestError, ForbiddenError, etc.), not the legacy ErrorApiException which only the AuthenticationApi
+                // token path throws; must be caught after the more-derived TooManyRequestsError above
+                Logger.LogError(e, "API error reconciling {EntityTypeName} {EntityNamespace}/{EntityName}: {Message}", EntityTypeName, entity.Namespace(), entity.Name(), e.Message);
+
+                try
+                {
+                    await ReconcileWarningAsync(entity, "ApiError", e.Message, cancellationToken);
+                }
+                catch (Exception e2)
+                {
+                    Logger.LogCritical(e2, "Unexpected exception creating event.");
+                }
+
+                // retry after the retry interval
+                var interval = Options.Reconciliation.RetryInterval;
+                Logger.LogDebug("{EntityTypeName} {Namespace}/{Name} scheduling next reconciliation in {IntervalSeconds}s", EntityTypeName, entity.Namespace(), entity.Name(), interval.TotalSeconds);
+                return ReconciliationResult<TEntity>.Failure(entity, e.Message, e, interval);
+            }
             catch (RetryException e)
             {
                 Logger.LogError(e, "Retry exception reconciling {EntityTypeName} {EntityNamespace}/{EntityName}: {Message}", EntityTypeName, entity.Namespace(), entity.Name(), e.Message);
@@ -667,6 +688,26 @@ namespace Alethic.Auth0.Operator.Controllers
                     interval = TimeSpan.FromMinutes(1);
 
                 Logger.LogInformation("Rescheduling deletion after {TimeSpan}.", interval);
+                return ReconciliationResult<TEntity>.Failure(entity, e.Message, e, interval);
+            }
+            catch (ManagementApiException e)
+            {
+                // the 8.x Auth0 Management SDK surfaces API errors as ManagementApiException subtypes (NotFoundError,
+                // TooManyRequestsError, etc.), not the legacy ErrorApiException which only the AuthenticationApi token path throws
+                Logger.LogError(e, "API error deleting {EntityTypeName} {EntityNamespace}/{EntityName}: {Message}", EntityTypeName, entity.Namespace(), entity.Name(), e.Message);
+
+                try
+                {
+                    await DeletingWarningAsync(entity, "ApiError", e.Message, cancellationToken);
+                }
+                catch (Exception e2)
+                {
+                    Logger.LogCritical(e2, "Unexpected exception creating event.");
+                }
+
+                // retry after the retry interval
+                var interval = Options.Reconciliation.RetryInterval;
+                Logger.LogDebug("{EntityTypeName} {Namespace}/{Name} scheduling next deletion in {IntervalSeconds}s", EntityTypeName, entity.Namespace(), entity.Name(), interval.TotalSeconds);
                 return ReconciliationResult<TEntity>.Failure(entity, e.Message, e, interval);
             }
             catch (RetryException e)

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3BrandingThemeController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3BrandingThemeController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,7 +7,6 @@ using Alethic.Auth0.Operator.Models;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
-using Auth0.Core.Exceptions;
 using Auth0.ManagementApi;
 using Auth0.ManagementApi.Branding;
 
@@ -612,7 +610,7 @@ namespace Alethic.Auth0.Operator.Controllers
             {
                 return FromApi(await api.Branding.Themes.GetAsync(id, cancellationToken: cancellationToken));
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 return null;
             }
@@ -631,7 +629,7 @@ namespace Alethic.Auth0.Operator.Controllers
                         Logger.LogInformation("{EntityTypeName} {EntityNamespace}/{EntityName} found existing theme: {DisplayName}", EntityTypeName, entity.Namespace(), entity.Name(), theme.DisplayName);
                         return theme.ThemeId;
                     }
-                    catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+                    catch (NotFoundError)
                     {
                         Logger.LogInformation("{EntityTypeName} {EntityNamespace}/{EntityName} could not find theme with id {ThemeId}.", EntityTypeName, entity.Namespace(), entity.Name(), id);
                         return null;

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ClientController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,7 +10,6 @@ using Alethic.Auth0.Operator.Models;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
-using Auth0.Core.Exceptions;
 using Auth0.ManagementApi;
 
 using k8s.Models;
@@ -1303,7 +1301,7 @@ namespace Alethic.Auth0.Operator.Controllers
             {
                 return FromApi(await api.Clients.GetAsync(id, new GetClientRequestParameters(), null, cancellationToken));
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 return null;
             }
@@ -1321,7 +1319,7 @@ namespace Alethic.Auth0.Operator.Controllers
                         Logger.LogInformation("{EntityTypeName} {EntityNamespace}/{EntityName} found existing client: {Name}", EntityTypeName, entity.Namespace(), entity.Name(), client.Name);
                         return client.ClientId;
                     }
-                    catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+                    catch (NotFoundError)
                     {
                         Logger.LogInformation("{EntityTypeName} {EntityNamespace}/{EntityName} could not find client with id {ClientId}.", EntityTypeName, entity.Namespace(), entity.Name(), clientId);
                     }

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionClientController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,7 +10,6 @@ using Alethic.Auth0.Operator.Models;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
-using Auth0.Core.Exceptions;
 using Auth0.ManagementApi;
 using Auth0.ManagementApi.Connections;
 
@@ -124,7 +122,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 if (await IsClientEnabledAsync(api, connectionId, clientId, cancellationToken) == false)
                     return null;
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 // connection no longer exists
                 return null;
@@ -157,7 +155,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 if (await IsClientEnabledAsync(api, connectionId, clientId, cancellationToken))
                     return BuildId(connectionId, clientId);
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 return null;
             }
@@ -210,7 +208,7 @@ namespace Alethic.Auth0.Operator.Controllers
             {
                 await SetClientEnabledAsync(api, connectionId, clientId, false, cancellationToken);
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 // connection already gone; nothing to disable
             }

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -14,7 +13,6 @@ using Alethic.Auth0.Operator.Models;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
-using Auth0.Core.Exceptions;
 using Auth0.ManagementApi;
 using Auth0.ManagementApi.Connections;
 using Auth0.ManagementApi.Core;
@@ -4520,7 +4518,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 conf.EnabledClients = (await GetEnabledClientsAsync(api, id, cancellationToken)).Select(i => new V1ClientReference() { Id = i }).ToArray();
                 return conf;
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 return null;
             }
@@ -4539,7 +4537,7 @@ namespace Alethic.Auth0.Operator.Controllers
                         Logger.LogInformation("{EntityTypeName} {EntityNamespace}/{EntityName} found existing connection: {Name}", EntityTypeName, entity.Namespace(), entity.Name(), connection.Name);
                         return connection.Id;
                     }
-                    catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+                    catch (NotFoundError)
                     {
                         Logger.LogInformation("{EntityTypeName} {EntityNamespace}/{EntityName} could not find connection with id {ConnectionId}.", EntityTypeName, entity.Namespace(), entity.Name(), connectionId);
                         return null;

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3CustomDomainController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3CustomDomainController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,7 +8,6 @@ using Alethic.Auth0.Operator.Models;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
-using Auth0.Core.Exceptions;
 using Auth0.ManagementApi;
 using Auth0.ManagementApi.Core;
 
@@ -159,7 +157,7 @@ namespace Alethic.Auth0.Operator.Controllers
             {
                 return FromApi(await api.CustomDomains.GetAsync(id, cancellationToken: cancellationToken));
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 return null;
             }

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ResourceServerController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ResourceServerController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,7 +9,6 @@ using Alethic.Auth0.Operator.Models;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
-using Auth0.Core.Exceptions;
 using Auth0.ManagementApi;
 
 using k8s.Models;
@@ -423,7 +421,7 @@ namespace Alethic.Auth0.Operator.Controllers
             {
                 return FromApi(await api.ResourceServers.GetAsync(id, new GetResourceServerRequestParameters(), null, cancellationToken));
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 return null;
             }

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3RoleController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3RoleController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +11,6 @@ using Alethic.Auth0.Operator.Models;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
-using Auth0.Core.Exceptions;
 using Auth0.ManagementApi;
 using Auth0.ManagementApi.Roles;
 
@@ -110,7 +108,7 @@ namespace Alethic.Auth0.Operator.Controllers
             {
                 self = await api.Roles.GetAsync(id, null, cancellationToken);
             }
-            catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            catch (NotFoundError)
             {
                 return null;
             }


### PR DESCRIPTION
## Problem

A `BrandingTheme` stopped applying and reconciled with an unhandled **`NotFoundError`**.

Root cause is an exception-type mismatch introduced by the Auth0 8.x SDK migration, and it is **not** BrandingTheme-specific — it affects every controller:

- The 8.x `Auth0.ManagementApi` client maps a 404 to `Auth0.ManagementApi.NotFoundError` (`: ManagementApiException : ManagementException : Exception`), thrown directly from the generated client's status-code switch. It has **no relationship** to the legacy `Auth0.Core.Exceptions.ErrorApiException`, which these clients never throw.
- Every controller's `Get`/`Find` still caught `catch (ErrorApiException e) when (e.StatusCode == HttpStatusCode.NotFound)`. That catch can never match a `NotFoundError`.

Consequence: the self-heal path in `V1TenantEntityInstanceController.ReconcileAsync` — where a `Get` returning `null` clears `status.Id` and recreates the remote entity — is dead. When a stored remote id is stale/missing (theme deleted externally, tenant re-provisioned, or a stale `spec.find.id`), the `NotFoundError` escapes and the reconcile hard-fails permanently. It surfaced on BrandingTheme because that was a resource whose stored id happened to be stale; any kind with a stale id fails identically.

## Fix

- Replace the `ErrorApiException` / `HttpStatusCode.NotFound` catches with `catch (NotFoundError)` in the `Get`/`Find` (and ConnectionClient disable-on-delete) paths of the **BrandingTheme, Client, Role, ResourceServer, Connection, ConnectionClient, and CustomDomain** controllers. Drop the now-unused `System.Net` / `Auth0.Core.Exceptions` imports.
- Add a `catch (ManagementApiException)` handler to `ControllerBase`'s reconcile and delete loops, ordered **after** the more-derived `TooManyRequestsError` catch, so any other 8.x Management API error becomes an `ApiError` event + retry instead of falling through to the generic catch-all. The legacy `ErrorApiException` / `RateLimitApiException` catches are intentionally **kept** — the `AuthenticationApiClient` token-acquisition path (`Auth0.AuthenticationApi` 7.46) still throws those.

## Tests

Added `V2alpha3BrandingThemeControllerNotFoundTests`, which drives the **real** SDK client through a fake 404 `HttpMessageHandler` to pin the contract the whole fix relies on:

- a 404 from the Management API surfaces as `NotFoundError`;
- `NotFoundError` is a `ManagementApiException` but is **not** the legacy `ErrorApiException`.

Full suite: **244 passed, 0 failed, 0 skipped** (`Microsoft.Testing.Platform` runner).

## Note

This does not migrate the `V2alpha3Tenant` controller's `api.Branding.*` calls, which have no NotFound handling today (branding settings always exist on a tenant, so they don't 404 in practice); the new `ControllerBase` `ManagementApiException` handler now degrades any stray case there to a retry rather than a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)