### PR TITLE
Default BrandingTheme displayName to "Unnamed Theme" when unset

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3BrandingThemeControllerMappingTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3BrandingThemeControllerMappingTests.cs
@@ -208,6 +208,21 @@ namespace Alethic.Auth0.Operator.Tests
         [TestMethod]
         public void ButtonsStyle_Roundtrip_Sharp() { var input = new BrandingThemeBordersButtonsStyleEnum(BrandingThemeBordersButtonsStyleEnum.Values.Sharp); Assert.AreEqual(input.Value, V2alpha3BrandingThemeController.ToApiButtonsStyle(V2alpha3BrandingThemeController.FromApi(input)).Value); }
 
+        // DisplayName defaulting: Auth0 omits displayName on read-back when a theme has none, and the SDK
+        // response models mark it required, so the create/update requests must always send a non-null value.
+
+        [TestMethod]
+        public void ToCreateRequest_DisplayName_DefaultsWhenNull() => Assert.AreEqual(V2alpha3BrandingThemeController.DefaultDisplayName, V2alpha3BrandingThemeController.ToCreateRequest(new V2alpha3BrandingThemeConf { DisplayName = null }).DisplayName);
+
+        [TestMethod]
+        public void ToCreateRequest_DisplayName_PreservedWhenSet() => Assert.AreEqual("Custom Theme", V2alpha3BrandingThemeController.ToCreateRequest(new V2alpha3BrandingThemeConf { DisplayName = "Custom Theme" }).DisplayName);
+
+        [TestMethod]
+        public void ToUpdateRequest_DisplayName_UsesExistingWhenConfNull() => Assert.AreEqual("Existing Theme", V2alpha3BrandingThemeController.ToUpdateRequest(new V2alpha3BrandingThemeConf { DisplayName = null }, new GetBrandingThemeResponseContent { Borders = null!, Colors = null!, DisplayName = "Existing Theme", Fonts = null!, PageBackground = null!, ThemeId = null!, Widget = null! }).DisplayName);
+
+        [TestMethod]
+        public void ToUpdateRequest_DisplayName_DefaultsWhenConfAndExistingNull() => Assert.AreEqual(V2alpha3BrandingThemeController.DefaultDisplayName, V2alpha3BrandingThemeController.ToUpdateRequest(new V2alpha3BrandingThemeConf { DisplayName = null }, new GetBrandingThemeResponseContent { Borders = null!, Colors = null!, DisplayName = null!, Fonts = null!, PageBackground = null!, ThemeId = null!, Widget = null! }).DisplayName);
+
     }
 
 }

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3BrandingThemeController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3BrandingThemeController.cs
@@ -279,11 +279,18 @@ namespace Alethic.Auth0.Operator.Controllers
         };
 
         /// <summary>
+        /// Default display name applied when none is configured. Auth0 assigns this same value to themes created
+        /// without a display name; sending it explicitly ensures the created/updated theme always carries a
+        /// <c>displayName</c>, which the Management API (and SDK response models) treat as required on read-back.
+        /// </summary>
+        internal const string DefaultDisplayName = "Unnamed Theme";
+
+        /// <summary>
         /// Converts the specified configuration to a new <see cref="CreateBrandingThemeRequestContent"/>.
         /// </summary>
         internal static CreateBrandingThemeRequestContent ToCreateRequest(V2alpha3BrandingThemeConf conf) => new()
         {
-            DisplayName = conf.DisplayName,
+            DisplayName = conf.DisplayName ?? DefaultDisplayName,
             Borders = ToApi(conf.Borders),
             Colors = ToApi(conf.Colors),
             Fonts = ToApi(conf.Fonts),
@@ -297,7 +304,7 @@ namespace Alethic.Auth0.Operator.Controllers
         /// </summary>
         internal static UpdateBrandingThemeRequestContent ToUpdateRequest(V2alpha3BrandingThemeConf conf, GetBrandingThemeResponseContent existing) => new()
         {
-            DisplayName = conf.DisplayName ?? existing?.DisplayName,
+            DisplayName = conf.DisplayName ?? existing?.DisplayName ?? DefaultDisplayName,
             Borders = ToApi(conf.Borders, existing?.Borders),
             Colors = ToApi(conf.Colors, existing?.Colors),
             Fonts = ToApi(conf.Fonts, existing?.Fonts),


### PR DESCRIPTION
## Problem

A `BrandingTheme` created without a `displayName` gets stuck in a permanent reconcile loop, emitting `ApiError: Failed to deserialize response` and never populating `status`.

Root cause is an upstream bug in the Auth0 .NET SDK: the branding-theme response models (`GetBrandingThemeResponseContent`, `GetBrandingDefaultThemeResponseContent`, `CreateBrandingThemeResponseContent`) mark `displayName` as a **required** member, but the Auth0 Management API **omits `displayName`** from the response for a theme that has none. `System.Text.Json` then throws, which the SDK rewraps as `ManagementApiException("Failed to deserialize response")` — on a valid HTTP 200.

This breaks the operator two ways for a theme with no display name:
- **Read** (`Get`/`Find` → `GetAsync`) throws, so the theme can never be reconciled.
- **Create** — the `POST` succeeds server-side, but the create *response* (also missing `displayName`) fails to deserialize, so `Create()` throws before `status.Id` is assigned. The theme is left **orphaned** in Auth0 with no display name, and every later reconcile fails to read it.

Verified end-to-end against live tenants: a theme **with** a `displayName` (`"Unnamed Theme"`) reads back fine; an otherwise-identical theme **without** one fails with `missing required properties including: 'displayName'`. Reproduced on SDK **8.3.0** and **9.1.0** (9.x marks even more fields `required`).

Upstream issue: auth0/auth0.net#1081

## Fix

Always send a non-null `displayName` on create/update so Auth0 echoes the field back on read:

- `ToCreateRequest`: `DisplayName = conf.DisplayName ?? DefaultDisplayName`
- `ToUpdateRequest`: `DisplayName = conf.DisplayName ?? existing?.DisplayName ?? DefaultDisplayName`
- `DefaultDisplayName = "Unnamed Theme"` — the value Auth0 itself assigns to a theme created without one, so a fresh theme reads back identically to an existing healthy one.

## Tests

Added mapping tests for create/update defaulting and preservation. Full suite passes (248/248).

## Scope note

This prevents the failure for any newly created theme. A theme **already** orphaned without a `displayName` still needs a one-time `PATCH` to set one (or a delete so it recreates cleanly), since `Find` throws before `Update` can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)