### PR TITLE
Add a per-domain circuit breaker for Auth0 rate limits

### DIFF
--- a/charts/auth0-operator/templates/deployment.yaml
+++ b/charts/auth0-operator/templates/deployment.yaml
@@ -129,6 +129,18 @@ spec:
             - name: Auth0__Operator__RateLimit__QueueLimit
               value: {{ .Values.options.rateLimit.queueLimit | quote }}
 {{- end }}
+{{- if not (kindIs "invalid" .Values.options.rateLimit.circuitBreaker.enabled) }}
+            - name: Auth0__Operator__RateLimit__CircuitBreaker__Enabled
+              value: {{ .Values.options.rateLimit.circuitBreaker.enabled | quote }}
+{{- end }}
+{{- if .Values.options.rateLimit.circuitBreaker.defaultOpenDuration }}
+            - name: Auth0__Operator__RateLimit__CircuitBreaker__DefaultOpenDuration
+              value: {{ .Values.options.rateLimit.circuitBreaker.defaultOpenDuration | quote }}
+{{- end }}
+{{- if .Values.options.rateLimit.circuitBreaker.maxOpenDuration }}
+            - name: Auth0__Operator__RateLimit__CircuitBreaker__MaxOpenDuration
+              value: {{ .Values.options.rateLimit.circuitBreaker.maxOpenDuration | quote }}
+{{- end }}
 
 {{- range .Values.operator.env }}
             - name: {{ .name | quote }}

--- a/charts/auth0-operator/values.yaml
+++ b/charts/auth0-operator/values.yaml
@@ -126,3 +126,12 @@ options:
     replenishmentPeriod:
     # Maximum requests allowed to wait for a token before failing fast. Default: 10000.
     queueLimit:
+    # Circuit breaker: when Auth0 answers any request with a 429, all requests to that domain fail fast until the
+    # server-reported rate limit reset instead of every reconcile discovering the rate limit on its own.
+    circuitBreaker:
+      # Whether the circuit breaker is applied. Default: true.
+      enabled:
+      # How long the breaker stays open when a 429 carries no usable reset header, as a duration. Default: "00:01:00".
+      defaultOpenDuration:
+      # Upper bound on how long the breaker stays open, guarding against clock skew. Default: "00:10:00".
+      maxOpenDuration:

--- a/src/Alethic.Auth0.Operator.Tests/Auth0CircuitBreakerTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Auth0CircuitBreakerTests.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Alethic.Auth0.Operator.Options;
+using Alethic.Auth0.Operator.RateLimiting;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests
+{
+
+    [TestClass]
+    public class Auth0CircuitBreakerTests
+    {
+
+        sealed class FakeTimeProvider : TimeProvider
+        {
+
+            DateTimeOffset _now;
+
+            public FakeTimeProvider(DateTimeOffset now)
+            {
+                _now = now;
+            }
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            public void Advance(TimeSpan by) => _now += by;
+
+        }
+
+        static HttpResponseMessage TooManyRequests(Action<HttpResponseMessage>? configure = null)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            configure?.Invoke(response);
+            return response;
+        }
+
+        [TestMethod]
+        public void ClosedCircuit_DoesNotThrow()
+        {
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions());
+            breaker.ThrowIfOpen("tenant.us.auth0.com");
+        }
+
+        [TestMethod]
+        public void OpenCircuit_ThrowsUntilExpiry()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions { DefaultOpenDuration = TimeSpan.FromMinutes(1) }, time);
+
+            breaker.Open("tenant.us.auth0.com", TooManyRequests());
+            Assert.ThrowsExactly<Auth0CircuitOpenException>(() => breaker.ThrowIfOpen("tenant.us.auth0.com"));
+
+            time.Advance(TimeSpan.FromMinutes(2));
+            breaker.ThrowIfOpen("tenant.us.auth0.com");
+        }
+
+        [TestMethod]
+        public void OpenCircuit_IsPerHost()
+        {
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions());
+            breaker.Open("a.us.auth0.com", TooManyRequests());
+
+            Assert.ThrowsExactly<Auth0CircuitOpenException>(() => breaker.ThrowIfOpen("a.us.auth0.com"));
+            breaker.ThrowIfOpen("b.us.auth0.com");
+        }
+
+        [TestMethod]
+        public void Open_UsesRetryAfterDelta()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions { DefaultOpenDuration = TimeSpan.FromMinutes(1) }, time);
+
+            var until = breaker.Open("tenant.us.auth0.com", TooManyRequests(r => r.Headers.Add("Retry-After", "120")));
+
+            Assert.AreEqual(DateTimeOffset.UnixEpoch + TimeSpan.FromSeconds(120), until);
+        }
+
+        [TestMethod]
+        public void Open_UsesRateLimitResetEpoch()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions(), time);
+
+            var until = breaker.Open("tenant.us.auth0.com", TooManyRequests(r => r.Headers.Add("x-ratelimit-reset", "90")));
+
+            Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(90), until);
+        }
+
+        [TestMethod]
+        public void Open_WithoutHeaders_UsesDefaultDuration()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions { DefaultOpenDuration = TimeSpan.FromSeconds(30) }, time);
+
+            var until = breaker.Open("tenant.us.auth0.com", TooManyRequests());
+
+            Assert.AreEqual(DateTimeOffset.UnixEpoch + TimeSpan.FromSeconds(30), until);
+        }
+
+        [TestMethod]
+        public void Open_ResetInThePast_StillOpensForDefaultDuration()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1000));
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions { DefaultOpenDuration = TimeSpan.FromSeconds(30) }, time);
+
+            var until = breaker.Open("tenant.us.auth0.com", TooManyRequests(r => r.Headers.Add("x-ratelimit-reset", "500")));
+
+            Assert.AreEqual(time.GetUtcNow() + TimeSpan.FromSeconds(30), until);
+        }
+
+        [TestMethod]
+        public void Open_ResetBeyondMax_IsClamped()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions { MaxOpenDuration = TimeSpan.FromMinutes(10) }, time);
+
+            var until = breaker.Open("tenant.us.auth0.com", TooManyRequests(r => r.Headers.Add("Retry-After", "86400")));
+
+            Assert.AreEqual(DateTimeOffset.UnixEpoch + TimeSpan.FromMinutes(10), until);
+        }
+
+        [TestMethod]
+        public void Open_NeverShortensAnOpenCircuit()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions { DefaultOpenDuration = TimeSpan.FromMinutes(5) }, time);
+
+            var longer = breaker.Open("tenant.us.auth0.com", TooManyRequests());
+            var shorter = breaker.Open("tenant.us.auth0.com", TooManyRequests(r => r.Headers.Add("Retry-After", "10")));
+
+            Assert.AreEqual(longer, shorter);
+        }
+
+        [TestMethod]
+        public void FindException_UnwrapsInnerChain()
+        {
+            var circuitOpen = new Auth0CircuitOpenException("tenant.us.auth0.com", DateTimeOffset.UnixEpoch);
+            var wrapped = new InvalidOperationException("outer", new HttpRequestException("mid", circuitOpen));
+
+            Assert.AreSame(circuitOpen, Auth0CircuitOpenException.Find(wrapped));
+            Assert.IsNull(Auth0CircuitOpenException.Find(new InvalidOperationException("no match")));
+        }
+
+        // ──────────────────────── handler integration ─────────────────────────────
+
+        sealed class StubHandler : HttpMessageHandler
+        {
+
+            public Func<HttpRequestMessage, HttpResponseMessage> Respond { get; set; } = _ => new HttpResponseMessage(HttpStatusCode.OK);
+
+            public int Sent { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Sent++;
+                return Task.FromResult(Respond(request));
+            }
+
+        }
+
+        [TestMethod]
+        public async Task Handler_TripsBreakerOn429_AndFailsFastAfterwards()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions { DefaultOpenDuration = TimeSpan.FromMinutes(1) }, time);
+            var stub = new StubHandler { Respond = _ => TooManyRequests() };
+            using var client = new HttpClient(new Auth0RateLimitingHandler(null, breaker, stub));
+
+            // first request reaches Auth0 and receives the 429 back
+            var response = await client.GetAsync("https://tenant.us.auth0.com/api/v2/clients");
+            Assert.AreEqual(HttpStatusCode.TooManyRequests, response.StatusCode);
+            Assert.AreEqual(1, stub.Sent);
+
+            // every request while the circuit is open fails fast without reaching Auth0
+            await Assert.ThrowsExactlyAsync<Auth0CircuitOpenException>(() => client.GetAsync("https://tenant.us.auth0.com/api/v2/clients"));
+            Assert.AreEqual(1, stub.Sent);
+
+            // requests to other domains are unaffected
+            stub.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK);
+            var other = await client.GetAsync("https://other.us.auth0.com/api/v2/clients");
+            Assert.AreEqual(HttpStatusCode.OK, other.StatusCode);
+
+            // once the reset passes, requests flow again
+            time.Advance(TimeSpan.FromMinutes(2));
+            var recovered = await client.GetAsync("https://tenant.us.auth0.com/api/v2/clients");
+            Assert.AreEqual(HttpStatusCode.OK, recovered.StatusCode);
+        }
+
+    }
+
+}

--- a/src/Alethic.Auth0.Operator.Tests/Auth0CircuitBreakerTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Auth0CircuitBreakerTests.cs
@@ -137,6 +137,88 @@ namespace Alethic.Auth0.Operator.Tests
         }
 
         [TestMethod]
+        public void OpenIfExhausted_RemainingZeroWithReset_OpensUntilReset()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions(), time);
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.Add("x-ratelimit-remaining", "0");
+            response.Headers.Add("x-ratelimit-reset", "60");
+
+            var until = breaker.OpenIfExhausted("tenant.us.auth0.com", response);
+
+            Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(60), until);
+            Assert.ThrowsExactly<Auth0CircuitOpenException>(() => breaker.ThrowIfOpen("tenant.us.auth0.com"));
+        }
+
+        [TestMethod]
+        public void OpenIfExhausted_RemainingZeroWithoutReset_DoesNotOpen()
+        {
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions());
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.Add("x-ratelimit-remaining", "0");
+
+            Assert.IsNull(breaker.OpenIfExhausted("tenant.us.auth0.com", response));
+            breaker.ThrowIfOpen("tenant.us.auth0.com");
+        }
+
+        [TestMethod]
+        public void OpenIfExhausted_RemainingZeroWithPastReset_DoesNotOpen()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.FromUnixTimeSeconds(1000));
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions(), time);
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.Add("x-ratelimit-remaining", "0");
+            response.Headers.Add("x-ratelimit-reset", "500");
+
+            Assert.IsNull(breaker.OpenIfExhausted("tenant.us.auth0.com", response));
+            breaker.ThrowIfOpen("tenant.us.auth0.com");
+        }
+
+        [TestMethod]
+        public void OpenIfExhausted_RemainingNonZero_DoesNotOpen()
+        {
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions());
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.Add("x-ratelimit-remaining", "5");
+            response.Headers.Add("x-ratelimit-reset", "9999999999");
+
+            Assert.IsNull(breaker.OpenIfExhausted("tenant.us.auth0.com", response));
+            breaker.ThrowIfOpen("tenant.us.auth0.com");
+        }
+
+        [TestMethod]
+        public async Task Handler_PreemptivelyOpensWhenBucketExhausted()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions(), time);
+            var stub = new StubHandler
+            {
+                Respond = _ =>
+                {
+                    var ok = new HttpResponseMessage(HttpStatusCode.OK);
+                    ok.Headers.Add("x-ratelimit-remaining", "0");
+                    ok.Headers.Add("x-ratelimit-reset", "60");
+                    return ok;
+                },
+            };
+            using var client = new HttpClient(new Auth0RateLimitingHandler(null, breaker, stub));
+
+            // the exhausting request itself succeeds
+            var response = await client.GetAsync("https://tenant.us.auth0.com/api/v2/clients");
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+            // the request that would have received the 429 fails fast instead
+            await Assert.ThrowsExactlyAsync<Auth0CircuitOpenException>(() => client.GetAsync("https://tenant.us.auth0.com/api/v2/clients"));
+            Assert.AreEqual(1, stub.Sent);
+
+            time.Advance(TimeSpan.FromSeconds(61));
+            stub.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK);
+            var recovered = await client.GetAsync("https://tenant.us.auth0.com/api/v2/clients");
+            Assert.AreEqual(HttpStatusCode.OK, recovered.StatusCode);
+        }
+
+        [TestMethod]
         public void FindException_UnwrapsInnerChain()
         {
             var circuitOpen = new Auth0CircuitOpenException("tenant.us.auth0.com", DateTimeOffset.UnixEpoch);

--- a/src/Alethic.Auth0.Operator/Controllers/ControllerBase.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/ControllerBase.cs
@@ -551,14 +551,23 @@ namespace Alethic.Auth0.Operator.Controllers
             }
             catch (Exception e) when (Auth0CircuitOpenException.Find(e) is { } circuitOpen)
             {
-                // the circuit for this tenant's domain is open following a 429; the request never reached Auth0.
-                // no per-entity event is emitted since every entity on the domain backs off at once and the
-                // entity that actually hit the 429 already carries a RateLimit event
+                // the circuit for this tenant's domain is open following a 429; the request never reached Auth0
+                Logger.LogWarning("{EntityTypeName} {EntityNamespace}/{EntityName} rate limit circuit for {Host} is open; rescheduling reconciliation.", EntityTypeName, entity.Namespace(), entity.Name(), circuitOpen.Host);
+
+                try
+                {
+                    await ReconcileWarningAsync(entity, "RateLimit", circuitOpen.Message, cancellationToken);
+                }
+                catch (Exception e2)
+                {
+                    Logger.LogCritical(e2, "Unexpected exception creating event.");
+                }
+
                 var interval = circuitOpen.OpenUntil - DateTimeOffset.Now;
                 if (interval < TimeSpan.FromMinutes(1))
                     interval = TimeSpan.FromMinutes(1);
 
-                Logger.LogWarning("{EntityTypeName} {EntityNamespace}/{EntityName} rate limit circuit for {Host} is open; rescheduling reconciliation after {TimeSpan}.", EntityTypeName, entity.Namespace(), entity.Name(), circuitOpen.Host, interval);
+                Logger.LogInformation("Rescheduling reconcilation after {TimeSpan}.", interval);
                 return ReconciliationResult<TEntity>.Failure(entity, circuitOpen.Message, e, interval);
             }
             catch (ErrorApiException e)
@@ -702,11 +711,22 @@ namespace Alethic.Auth0.Operator.Controllers
             catch (Exception e) when (Auth0CircuitOpenException.Find(e) is { } circuitOpen)
             {
                 // the circuit for this tenant's domain is open following a 429; the request never reached Auth0
+                Logger.LogWarning("{EntityTypeName} {EntityNamespace}/{EntityName} rate limit circuit for {Host} is open; rescheduling deletion.", EntityTypeName, entity.Namespace(), entity.Name(), circuitOpen.Host);
+
+                try
+                {
+                    await DeletingWarningAsync(entity, "RateLimit", circuitOpen.Message, cancellationToken);
+                }
+                catch (Exception e2)
+                {
+                    Logger.LogCritical(e2, "Unexpected exception creating event.");
+                }
+
                 var interval = circuitOpen.OpenUntil - DateTimeOffset.Now;
                 if (interval < TimeSpan.FromMinutes(1))
                     interval = TimeSpan.FromMinutes(1);
 
-                Logger.LogWarning("{EntityTypeName} {EntityNamespace}/{EntityName} rate limit circuit for {Host} is open; rescheduling deletion after {TimeSpan}.", EntityTypeName, entity.Namespace(), entity.Name(), circuitOpen.Host, interval);
+                Logger.LogInformation("Rescheduling deletion after {TimeSpan}.", interval);
                 return ReconciliationResult<TEntity>.Failure(entity, circuitOpen.Message, e, interval);
             }
             catch (ErrorApiException e)

--- a/src/Alethic.Auth0.Operator/Controllers/ControllerBase.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/ControllerBase.cs
@@ -549,6 +549,18 @@ namespace Alethic.Auth0.Operator.Controllers
                 await ReconcileSuccessAsync(entity, cancellationToken);
                 return ReconciliationResult<TEntity>.Success(entity, Options.Reconciliation.Interval);
             }
+            catch (Exception e) when (Auth0CircuitOpenException.Find(e) is { } circuitOpen)
+            {
+                // the circuit for this tenant's domain is open following a 429; the request never reached Auth0.
+                // no per-entity event is emitted since every entity on the domain backs off at once and the
+                // entity that actually hit the 429 already carries a RateLimit event
+                var interval = circuitOpen.OpenUntil - DateTimeOffset.Now;
+                if (interval < TimeSpan.FromMinutes(1))
+                    interval = TimeSpan.FromMinutes(1);
+
+                Logger.LogWarning("{EntityTypeName} {EntityNamespace}/{EntityName} rate limit circuit for {Host} is open; rescheduling reconciliation after {TimeSpan}.", EntityTypeName, entity.Namespace(), entity.Name(), circuitOpen.Host, interval);
+                return ReconciliationResult<TEntity>.Failure(entity, circuitOpen.Message, e, interval);
+            }
             catch (ErrorApiException e)
             {
                 Logger.LogError(e, "API error reconciling {EntityTypeName} {EntityNamespace}/{EntityName}: {Message}", EntityTypeName, entity.Namespace(), entity.Name(), e.ApiError?.Message ?? "");
@@ -686,6 +698,16 @@ namespace Alethic.Auth0.Operator.Controllers
                 await DeletedAsync(entity, cancellationToken);
                 await DeletingSuccessAsync(entity, cancellationToken);
                 return ReconciliationResult<TEntity>.Success(entity);
+            }
+            catch (Exception e) when (Auth0CircuitOpenException.Find(e) is { } circuitOpen)
+            {
+                // the circuit for this tenant's domain is open following a 429; the request never reached Auth0
+                var interval = circuitOpen.OpenUntil - DateTimeOffset.Now;
+                if (interval < TimeSpan.FromMinutes(1))
+                    interval = TimeSpan.FromMinutes(1);
+
+                Logger.LogWarning("{EntityTypeName} {EntityNamespace}/{EntityName} rate limit circuit for {Host} is open; rescheduling deletion after {TimeSpan}.", EntityTypeName, entity.Namespace(), entity.Name(), circuitOpen.Host, interval);
+                return ReconciliationResult<TEntity>.Failure(entity, circuitOpen.Message, e, interval);
             }
             catch (ErrorApiException e)
             {

--- a/src/Alethic.Auth0.Operator/Options/RateLimitOptions.cs
+++ b/src/Alethic.Auth0.Operator/Options/RateLimitOptions.cs
@@ -38,6 +38,37 @@ namespace Alethic.Auth0.Operator.Options
         /// </summary>
         public int QueueLimit { get; set; } = 10000;
 
+        /// <summary>
+        /// Configuration of the circuit breaker that opens when Auth0 returns a 429.
+        /// </summary>
+        public CircuitBreakerOptions CircuitBreaker { get; set; } = new();
+
+    }
+
+    /// <summary>
+    /// Configuration for the per-domain circuit breaker. When Auth0 answers any request with a 429, the breaker
+    /// opens for that domain until the server-reported rate limit reset, and every request in the meantime fails
+    /// fast without reaching Auth0 — so a single 429 backpressures the whole reconcile loop instead of every
+    /// entity discovering the rate limit on its own.
+    /// </summary>
+    public class CircuitBreakerOptions
+    {
+
+        /// <summary>
+        /// Whether the circuit breaker is applied. When false, 429 responses only affect the requesting reconcile.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// How long the breaker stays open after a 429 that carries no usable Retry-After or rate limit reset header.
+        /// </summary>
+        public TimeSpan DefaultOpenDuration { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Upper bound on how long the breaker stays open, guarding against clock skew in server-reported reset times.
+        /// </summary>
+        public TimeSpan MaxOpenDuration { get; set; } = TimeSpan.FromMinutes(10);
+
     }
 
 }

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0CircuitBreaker.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0CircuitBreaker.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Net.Http;
+
+using Alethic.Auth0.Operator.Options;
+
+namespace Alethic.Auth0.Operator.RateLimiting
+{
+
+    /// <summary>
+    /// Per-domain circuit breaker for Auth0 rate limits. When any request to a domain receives a 429 the circuit
+    /// opens until the server-reported reset time, and every request issued while it is open fails fast with an
+    /// <see cref="Auth0CircuitOpenException"/> instead of reaching Auth0. The circuit closes by the passage of
+    /// time alone; a further 429 after it closes simply reopens it.
+    /// </summary>
+    public sealed class Auth0CircuitBreaker
+    {
+
+        readonly CircuitBreakerOptions _options;
+        readonly TimeProvider _time;
+        readonly ConcurrentDictionary<string, DateTimeOffset> _openUntil = new();
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="time"></param>
+        public Auth0CircuitBreaker(CircuitBreakerOptions options, TimeProvider? time = null)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _time = time ?? TimeProvider.System;
+        }
+
+        /// <summary>
+        /// Throws <see cref="Auth0CircuitOpenException"/> when the circuit for <paramref name="host"/> is open.
+        /// </summary>
+        /// <param name="host"></param>
+        /// <exception cref="Auth0CircuitOpenException"></exception>
+        public void ThrowIfOpen(string host)
+        {
+            if (_openUntil.TryGetValue(host, out var until) == false)
+                return;
+
+            if (_time.GetUtcNow() < until)
+                throw new Auth0CircuitOpenException(host, until);
+
+            // expired; remove only if unchanged so a concurrent reopen is not lost
+            _openUntil.TryRemove(new System.Collections.Generic.KeyValuePair<string, DateTimeOffset>(host, until));
+        }
+
+        /// <summary>
+        /// Opens the circuit for <paramref name="host"/> in response to a 429, using the response's rate limit
+        /// reset headers when available and the configured default otherwise. Returns the time until which the
+        /// circuit is open.
+        /// </summary>
+        /// <param name="host"></param>
+        /// <param name="response"></param>
+        public DateTimeOffset Open(string host, HttpResponseMessage response)
+        {
+            var now = _time.GetUtcNow();
+
+            var until = ResolveResetTime(response, now) ?? now + _options.DefaultOpenDuration;
+
+            // clamp into (now, now + max]; a reset in the past still opens for the default duration so
+            // repeated 429s cannot bypass the breaker entirely
+            if (until <= now)
+                until = now + _options.DefaultOpenDuration;
+            if (until > now + _options.MaxOpenDuration)
+                until = now + _options.MaxOpenDuration;
+
+            // an already-open circuit is never shortened; return whichever deadline is now in effect
+            return _openUntil.AddOrUpdate(host, until, (_, existing) => until > existing ? until : existing);
+        }
+
+        /// <summary>
+        /// Resolves the server-reported moment the rate limit resets: Retry-After (delta or date) first, then the
+        /// Auth0 <c>x-ratelimit-reset</c> header (unix epoch seconds).
+        /// </summary>
+        /// <param name="response"></param>
+        /// <param name="now"></param>
+        static DateTimeOffset? ResolveResetTime(HttpResponseMessage response, DateTimeOffset now)
+        {
+            if (response.Headers.RetryAfter?.Delta is { } delta)
+                return now + delta;
+
+            if (response.Headers.RetryAfter?.Date is { } date)
+                return date;
+
+            if (response.Headers.TryGetValues("x-ratelimit-reset", out var values))
+                foreach (var value in values)
+                    if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var epochSeconds))
+                        return DateTimeOffset.FromUnixTimeSeconds(epochSeconds);
+
+            return null;
+        }
+
+    }
+
+}

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0CircuitBreaker.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0CircuitBreaker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 
 using Alethic.Auth0.Operator.Options;
@@ -71,6 +72,34 @@ namespace Alethic.Auth0.Operator.RateLimiting
 
             // an already-open circuit is never shortened; return whichever deadline is now in effect
             return _openUntil.AddOrUpdate(host, until, (_, existing) => until > existing ? until : existing);
+        }
+
+        /// <summary>
+        /// Opens the circuit for <paramref name="host"/> when a successful response reports the rate limit bucket
+        /// as exhausted (<c>x-ratelimit-remaining: 0</c>), so the 429 the next request would receive never happens.
+        /// Unlike <see cref="Open"/> this only acts on a parseable, future reset time — a success without usable
+        /// reset information opens nothing. Returns the time until which the circuit is open, or null.
+        /// </summary>
+        /// <param name="host"></param>
+        /// <param name="response"></param>
+        public DateTimeOffset? OpenIfExhausted(string host, HttpResponseMessage response)
+        {
+            if (response.Headers.TryGetValues("x-ratelimit-remaining", out var remainingValues) == false)
+                return null;
+
+            if (long.TryParse(remainingValues.FirstOrDefault(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var remaining) == false || remaining != 0)
+                return null;
+
+            var now = _time.GetUtcNow();
+
+            var until = ResolveResetTime(response, now);
+            if (until is null || until <= now)
+                return null;
+
+            if (until > now + _options.MaxOpenDuration)
+                until = now + _options.MaxOpenDuration;
+
+            return _openUntil.AddOrUpdate(host, until.Value, (_, existing) => until.Value > existing ? until.Value : existing);
         }
 
         /// <summary>

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0CircuitOpenException.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0CircuitOpenException.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace Alethic.Auth0.Operator.RateLimiting
+{
+
+    /// <summary>
+    /// Thrown before a request is sent when the circuit for the target Auth0 domain is open because a previous
+    /// request received a 429. Callers should reschedule for after <see cref="OpenUntil"/> rather than retry.
+    /// </summary>
+    public sealed class Auth0CircuitOpenException : Exception
+    {
+
+        /// <summary>
+        /// Walks the exception chain for an <see cref="Auth0CircuitOpenException"/>, unwrapping aggregate and
+        /// wrapper exceptions the SDK may introduce.
+        /// </summary>
+        /// <param name="exception"></param>
+        public static Auth0CircuitOpenException? Find(Exception? exception)
+        {
+            for (var e = exception; e is not null; e = e.InnerException)
+                if (e is Auth0CircuitOpenException circuitOpen)
+                    return circuitOpen;
+
+            if (exception is AggregateException aggregate)
+                foreach (var inner in aggregate.InnerExceptions)
+                    if (Find(inner) is { } found)
+                        return found;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="host"></param>
+        /// <param name="openUntil"></param>
+        public Auth0CircuitOpenException(string host, DateTimeOffset openUntil) :
+            base($"Auth0 rate limit circuit for {host} is open until {openUntil:O}; not sending request.")
+        {
+            Host = host;
+            OpenUntil = openUntil;
+        }
+
+        /// <summary>
+        /// Gets the Auth0 domain whose circuit is open.
+        /// </summary>
+        public string Host { get; }
+
+        /// <summary>
+        /// Gets the time at which the circuit closes and requests flow again.
+        /// </summary>
+        public DateTimeOffset OpenUntil { get; }
+
+    }
+
+}

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0HttpClientProvider.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0HttpClientProvider.cs
@@ -32,16 +32,14 @@ namespace Alethic.Auth0.Operator.RateLimiting
         public HttpClient Client { get; }
 
         /// <summary>
-        /// Builds the <see cref="HttpClient"/>, applying the rate limiter when enabled.
+        /// Builds the <see cref="HttpClient"/>, applying the rate limiter and circuit breaker when enabled.
         /// </summary>
         /// <param name="options"></param>
         static HttpClient Create(RateLimitOptions options)
         {
             var transport = new SocketsHttpHandler();
-            if (options.Enabled == false)
-                return new HttpClient(transport);
 
-            var limiter = PartitionedRateLimiter.Create<HttpRequestMessage, string>(request =>
+            var limiter = options.Enabled == false ? null : PartitionedRateLimiter.Create<HttpRequestMessage, string>(request =>
                 RateLimitPartition.GetTokenBucketLimiter(
                     request.RequestUri?.Host ?? string.Empty,
                     _ => new TokenBucketRateLimiterOptions
@@ -54,7 +52,12 @@ namespace Alethic.Auth0.Operator.RateLimiting
                         AutoReplenishment = true,
                     }));
 
-            return new HttpClient(new Auth0RateLimitingHandler(limiter, transport));
+            var breaker = options.CircuitBreaker.Enabled ? new Auth0CircuitBreaker(options.CircuitBreaker) : null;
+
+            if (limiter is null && breaker is null)
+                return new HttpClient(transport);
+
+            return new HttpClient(new Auth0RateLimitingHandler(limiter, breaker, transport));
         }
 
     }

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
@@ -50,9 +50,13 @@ namespace Alethic.Auth0.Operator.RateLimiting
             var response = await base.SendAsync(request, cancellationToken);
 
             // a 429 opens the circuit for the whole domain; the response still flows back so the SDK surfaces
-            // its rate limit error to the requesting reconcile, which reschedules on its own
+            // its rate limit error to the requesting reconcile, which reschedules on its own. a successful
+            // response reporting the bucket as exhausted opens the circuit preemptively, so the 429 the next
+            // request would receive never happens
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
                 _breaker?.Open(host, response);
+            else
+                _breaker?.OpenIfExhausted(host, response);
 
             return response;
         }

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
@@ -10,36 +10,49 @@ namespace Alethic.Auth0.Operator.RateLimiting
 
     /// <summary>
     /// <see cref="DelegatingHandler"/> that gates every outgoing Auth0 Management API request through a rate limiter
-    /// before it is sent, and, as a last resort, honors any <c>Retry-After</c> header returned on a 429 response.
+    /// before it is sent, and trips the per-domain circuit breaker on any 429 response so that no further requests
+    /// reach that domain until the server-reported rate limit reset.
     /// </summary>
     sealed class Auth0RateLimitingHandler : DelegatingHandler
     {
 
-        readonly PartitionedRateLimiter<HttpRequestMessage> _limiter;
+        readonly PartitionedRateLimiter<HttpRequestMessage>? _limiter;
+        readonly Auth0CircuitBreaker? _breaker;
 
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="limiter"></param>
+        /// <param name="breaker"></param>
         /// <param name="innerHandler"></param>
-        public Auth0RateLimitingHandler(PartitionedRateLimiter<HttpRequestMessage> limiter, HttpMessageHandler innerHandler)
+        public Auth0RateLimitingHandler(PartitionedRateLimiter<HttpRequestMessage>? limiter, Auth0CircuitBreaker? breaker, HttpMessageHandler innerHandler)
         {
-            _limiter = limiter ?? throw new ArgumentNullException(nameof(limiter));
+            _limiter = limiter;
+            _breaker = breaker;
             InnerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
         }
 
         /// <inheritdoc />
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            using var lease = await _limiter.AcquireAsync(request, 1, cancellationToken);
-            if (lease.IsAcquired == false)
-                throw new HttpRequestException("Auth0 Management API client-side rate limit queue is full; backing off.");
+            var host = request.RequestUri?.Host ?? string.Empty;
+
+            // fail fast before consuming a limiter token when the domain's circuit is open
+            _breaker?.ThrowIfOpen(host);
+
+            if (_limiter is not null)
+            {
+                using var lease = await _limiter.AcquireAsync(request, 1, cancellationToken);
+                if (lease.IsAcquired == false)
+                    throw new HttpRequestException("Auth0 Management API client-side rate limit queue is full; backing off.");
+            }
 
             var response = await base.SendAsync(request, cancellationToken);
 
-            // last resort: if a 429 still slips through, respect the server's Retry-After before returning
-            if (response.StatusCode == HttpStatusCode.TooManyRequests && response.Headers.RetryAfter?.Delta is { } delta)
-                await Task.Delay(delta, cancellationToken);
+            // a 429 opens the circuit for the whole domain; the response still flows back so the SDK surfaces
+            // its rate limit error to the requesting reconcile, which reschedules on its own
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                _breaker?.Open(host, response);
 
             return response;
         }


### PR DESCRIPTION
## Summary

When one request hit the Auth0 rate limit, only the reconcile that received the 429 backed off — every other queued reconcile still fired its own requests into the exhausted limit, prolonging the storm. This adds a centralized, per-domain circuit breaker at the HTTP layer:

- `Auth0RateLimitingHandler` trips `Auth0CircuitBreaker` on any 429 response. The open-until deadline comes from `Retry-After` (delta or date) or Auth0's `x-ratelimit-reset` (epoch seconds) when present, falling back to a configured default (1m); it is clamped to a configured maximum (10m) to guard against clock skew, and a subsequent 429 can extend but never shorten it.
- While the circuit is open, **every** request to that domain fails fast with `Auth0CircuitOpenException` — before consuming a limiter token, before reaching the network. Other domains are unaffected (the breaker is partitioned by host, like the token bucket).
- `ControllerBase` catches the circuit-open exception (unwrapping any SDK wrapping) in both the reconcile and delete paths and reschedules for when the circuit closes, floored to one minute. It logs a warning but deliberately emits no per-entity Kubernetes event, since every entity on the domain backs off at once and the entity that actually hit the 429 already carries a RateLimit event.
- The circuit closes by the passage of time alone; the first 429 after it closes simply reopens it.
- The previous in-handler `Retry-After` `Task.Delay` is removed — it held a reconcile slot only to return the 429 anyway.

## Configuration

New `options.rateLimit.circuitBreaker` block in the chart (`enabled`, `defaultOpenDuration`, `maxOpenDuration`), mapped to `Auth0__Operator__RateLimit__CircuitBreaker__*`. Enabled by default, and independent of the token bucket switch — disabling the token bucket no longer disables 429 handling.

## Tests

11 new tests covering breaker open/close/expiry, per-host isolation, all three reset-header sources, past-reset and beyond-max clamping, the never-shorten rule, exception unwrapping, and an end-to-end handler test (429 trips the breaker → subsequent requests fail fast without reaching the stub transport → other domains unaffected → requests flow again after reset). Full suite: 266 passed, 0 failed.