### PR TITLE
Update GitHub Actions to current majors and GitVersion tool to 6.8.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "gitversion.tool": {
-      "version": "6.5.1",
+      "version": "6.8.2",
       "commands": [
         "dotnet-gitversion"
       ],

--- a/.github/workflows/Alethic.Auth0.Operator.yml
+++ b/.github/workflows/Alethic.Auth0.Operator.yml
@@ -17,14 +17,14 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Setup .NET 10
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.x
     - name: Add NuGet Source (GitHub)
@@ -66,7 +66,7 @@ jobs:
           Alethic.Auth0.Operator.dist.msbuildproj
     - name: Upload MSBuild Log
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: msbuild.binlog
         path: msbuild.binlog
@@ -74,7 +74,7 @@ jobs:
       run: tar czvf /tmp/images.tar.gz images
       working-directory: dist
     - name: Upload Images
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: images
         path: /tmp/images.tar.gz
@@ -82,7 +82,7 @@ jobs:
       run: tar czvf /tmp/charts.tar.gz charts
       working-directory: dist
     - name: Upload Charts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: charts
         path: /tmp/charts.tar.gz
@@ -90,7 +90,7 @@ jobs:
       run: tar czvf /tmp/tests.tar.gz tests
       working-directory: dist
     - name: Upload Tests
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: tests
         path: /tmp/tests.tar.gz
@@ -99,14 +99,14 @@ jobs:
     if: github.event_name != 'pull_request'
     needs:
     - build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Setup .NET 10
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.x
     - name: Install GitVersion
@@ -117,7 +117,7 @@ jobs:
       id: GitVersion
       uses: gittools/actions/gitversion/execute@v4
     - name: Download Images
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: images
         path: dist
@@ -125,7 +125,7 @@ jobs:
       run: tar xzvf images.tar.gz
       working-directory: dist
     - name: Download Charts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: charts
         path: dist
@@ -143,7 +143,7 @@ jobs:
         makeLatest: true
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Login To Repository (GitHub)
-      uses: redhat-actions/podman-login@v1
+      uses: redhat-actions/podman-login@v2
       with:
         username: ${{ github.actor }}
         password: ${{ github.token }}


### PR DESCRIPTION
## Summary

Modernizes the CI workflow to the current major of every action, plus the runner image:

| Component | From | To |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-dotnet` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `redhat-actions/podman-login` | v1 | v2 |
| runner image | ubuntu-22.04 | ubuntu-24.04 |
| `gitversion.tool` (dotnet-tools.json) | 6.5.1 | 6.8.2 |

Unchanged because already current: `gittools/actions@v4` (floats to 4.7.0), `ncipollo/release-action@v1` (rolling major, 1.21.0), the skopeo image (rolling `stable`).

## GitVersion

Handled with care per the known config-drift risk, and it turns out no `GitVersion.yml` changes are needed:

- There is no GitVersion 7 — 6.8.2 is the latest release, and the 5→6 migration was already done in #22.
- CI installs via `versionSpec: 6.x`, which floats — today''s `1.4.8-pre.*` builds were **already produced by GitVersion 6.8.2** against the current `GitVersion.yml`, so the config is proven in production.
- The only stale pin was the local tool manifest (6.5.1). Verified locally that 6.8.2 parses the config cleanly and computes a version identical to 6.5.1 on the same commit.

## Action major compatibility

The workflow uses only basic inputs of each action (`fetch-depth`, `dotnet-version`, artifact `name`/`path`, registry credentials); none of these inputs changed semantics across the skipped majors — they are Node runtime/infrastructure updates.