### PR TITLE
Compare delimited scope strings as unordered token sets

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3ConnectionNeedsUpdateTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3ConnectionNeedsUpdateTests.cs
@@ -400,6 +400,35 @@ namespace Alethic.Auth0.Operator.Tests
             Assert.IsTrue(V2alpha3ConnectionController.ConfRequiresUpdate(conf, last));
         }
 
+        [TestMethod]
+        public void ConfRequiresUpdate_ReorderedAppleScopeString_ReturnsFalse()
+        {
+            // Auth0 normalizes the token order of delimited scope strings; "name email" vs "email name" is not
+            // drift (this exact skew caused the apple connections to re-update every cycle in labs)
+            var conf = new V2alpha3ConnectionConf { Options = new V2alpha3ConnectionOptions { Apple = new V2alpha3ConnectionOptionsApple { Scope = "name email" } } };
+            var last = new V2alpha3ConnectionConf { Options = new V2alpha3ConnectionOptions { Apple = new V2alpha3ConnectionOptionsApple { Scope = "email name" } } };
+
+            Assert.IsFalse(V2alpha3ConnectionController.ConfRequiresUpdate(conf, last));
+        }
+
+        [TestMethod]
+        public void ConfRequiresUpdate_ChangedAppleScopeToken_ReturnsTrue()
+        {
+            var conf = new V2alpha3ConnectionConf { Options = new V2alpha3ConnectionOptions { Apple = new V2alpha3ConnectionOptionsApple { Scope = "name email" } } };
+            var last = new V2alpha3ConnectionConf { Options = new V2alpha3ConnectionOptions { Apple = new V2alpha3ConnectionOptionsApple { Scope = "email" } } };
+
+            Assert.IsTrue(V2alpha3ConnectionController.ConfRequiresUpdate(conf, last));
+        }
+
+        [TestMethod]
+        public void ConfRequiresUpdate_CommaDelimitedFacebookScope_ComparedAsTokenSet()
+        {
+            var conf = new V2alpha3ConnectionConf { Options = new V2alpha3ConnectionOptions { Facebook = new V2alpha3ConnectionOptionsFacebook { Scope = "email,public_profile" } } };
+            var last = new V2alpha3ConnectionConf { Options = new V2alpha3ConnectionOptions { Facebook = new V2alpha3ConnectionOptionsFacebook { Scope = "public_profile email" } } };
+
+            Assert.IsFalse(V2alpha3ConnectionController.ConfRequiresUpdate(conf, last));
+        }
+
     }
 
 }

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionController.cs
@@ -5859,6 +5859,26 @@ namespace Alethic.Auth0.Operator.Controllers
             return false;
         }
 
+        /// <summary>
+        /// Compares a delimited scope string (Apple, Facebook, Oidc, Okta) as an unordered token set. Auth0
+        /// normalizes the token order on its side, so a reordered scope string is not drift — and comparing it
+        /// ordinally would re-issue an update every cycle without ever converging.
+        /// </summary>
+        static bool ScopeRequiresUpdate(string? conf, string? last)
+        {
+            if (conf is null)
+                return false;
+
+            if (last is null)
+                return true;
+
+            var confTokens = conf.Split(ScopeSeparators, StringSplitOptions.RemoveEmptyEntries);
+            var lastTokens = last.Split(ScopeSeparators, StringSplitOptions.RemoveEmptyEntries);
+            return confTokens.ToHashSet().SetEquals(lastTokens) == false;
+        }
+
+        static readonly char[] ScopeSeparators = [' ', ',', '\t'];
+
         static bool RequiresUpdate(V2alpha3ConnectionOptionsApple? conf, V2alpha3ConnectionOptionsApple? last)
         {
             if (conf is null)
@@ -5885,7 +5905,7 @@ namespace Alethic.Auth0.Operator.Controllers
             if (conf.Name is not null && conf.Name != last.Name)
                 return true;
 
-            if (conf.Scope is not null && conf.Scope != last.Scope)
+            if (ScopeRequiresUpdate(conf.Scope, last.Scope))
                 return true;
 
             if (conf.SetUserRootAttributes is not null && conf.SetUserRootAttributes != last.SetUserRootAttributes)
@@ -6491,7 +6511,7 @@ namespace Alethic.Auth0.Operator.Controllers
             if (RequiresUpdate(conf.UpstreamParams, last.UpstreamParams))
                 return true;
 
-            if (conf.Scope is not null && conf.Scope != last.Scope)
+            if (ScopeRequiresUpdate(conf.Scope, last.Scope))
                 return true;
 
             if (conf.SetUserRootAttributes is not null && conf.SetUserRootAttributes != last.SetUserRootAttributes)
@@ -7390,7 +7410,7 @@ namespace Alethic.Auth0.Operator.Controllers
             if (RequiresUpdate(conf.OidcMetadata, last.OidcMetadata))
                 return true;
 
-            if (conf.Scope is not null && conf.Scope != last.Scope)
+            if (ScopeRequiresUpdate(conf.Scope, last.Scope))
                 return true;
 
             if (conf.SendBackChannelNonce is not null && conf.SendBackChannelNonce != last.SendBackChannelNonce)
@@ -7638,7 +7658,7 @@ namespace Alethic.Auth0.Operator.Controllers
             if (RequiresUpdate(conf.OidcMetadata, last.OidcMetadata))
                 return true;
 
-            if (conf.Scope is not null && conf.Scope != last.Scope)
+            if (ScopeRequiresUpdate(conf.Scope, last.Scope))
                 return true;
 
             if (conf.SendBackChannelNonce is not null && conf.SendBackChannelNonce != last.SendBackChannelNonce)


### PR DESCRIPTION
## Summary

Observed in labs on 1.4.8-pre.9: the apple connections re-updated on every reconcile cycle. Their spec sets `options.apple.scope: "name email"` while Auth0 returns the normalized `"email name"` — the drift comparer did an ordinal string compare, saw permanent drift, and issued a PATCH every cycle that could never converge.

Apple, Facebook, Oidc and Okta options all carry their OAuth scope as a single delimited string with set semantics. The comparer now splits on whitespace and commas and compares the tokens as an unordered set (`ScopeRequiresUpdate`), consistent with the array-typed scope fields that already compare as sets. (`V2alpha3ConnectionOptionsCommonOidc` also has a string scope but is entirely unreferenced by the controller — dead model type, untouched.)

## Tests

Three new tests: the exact production skew (`"name email"` vs `"email name"`) → no update; a genuinely removed token → update; comma-vs-space delimited equivalence (Facebook) → no update. Full suite: 385 passed.