### PR TITLE
Pace requests to the refill rate as the rate limit budget depletes

### DIFF
--- a/charts/auth0-operator/templates/deployment.yaml
+++ b/charts/auth0-operator/templates/deployment.yaml
@@ -141,6 +141,18 @@ spec:
             - name: Auth0__Operator__RateLimit__CircuitBreaker__MaxOpenDuration
               value: {{ .Values.options.rateLimit.circuitBreaker.maxOpenDuration | quote }}
 {{- end }}
+{{- if not (kindIs "invalid" .Values.options.rateLimit.pacing.enabled) }}
+            - name: Auth0__Operator__RateLimit__Pacing__Enabled
+              value: {{ .Values.options.rateLimit.pacing.enabled | quote }}
+{{- end }}
+{{- if .Values.options.rateLimit.pacing.remainingThreshold }}
+            - name: Auth0__Operator__RateLimit__Pacing__RemainingThreshold
+              value: {{ .Values.options.rateLimit.pacing.remainingThreshold | quote }}
+{{- end }}
+{{- if .Values.options.rateLimit.pacing.maxRequestDelay }}
+            - name: Auth0__Operator__RateLimit__Pacing__MaxRequestDelay
+              value: {{ .Values.options.rateLimit.pacing.maxRequestDelay | quote }}
+{{- end }}
 
 {{- range .Values.operator.env }}
             - name: {{ .name | quote }}

--- a/charts/auth0-operator/values.yaml
+++ b/charts/auth0-operator/values.yaml
@@ -135,3 +135,13 @@ options:
       defaultOpenDuration:
       # Upper bound on how long the breaker stays open, guarding against clock skew. Default: "00:10:00".
       maxOpenDuration:
+    # Adaptive pacing: as Auth0's reported remaining budget depletes, outbound requests are delayed so the rest of
+    # the budget is spread across the time until the reset — consumption slows to Auth0's refill rate instead of
+    # draining the bucket and tripping the circuit breaker.
+    pacing:
+      # Whether adaptive pacing is applied. Default: true.
+      enabled:
+      # The remaining budget at or below which pacing begins. Default: 10.
+      remainingThreshold:
+      # Upper bound on the delay applied to a single request, as a duration. Default: "00:00:10".
+      maxRequestDelay:

--- a/src/Alethic.Auth0.Operator.Tests/Auth0CircuitBreakerTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Auth0CircuitBreakerTests.cs
@@ -202,7 +202,7 @@ namespace Alethic.Auth0.Operator.Tests
                     return ok;
                 },
             };
-            using var client = new HttpClient(new Auth0RateLimitingHandler(null, breaker, stub));
+            using var client = new HttpClient(new Auth0RateLimitingHandler(null, breaker, null, stub));
 
             // the exhausting request itself succeeds
             var response = await client.GetAsync("https://tenant.us.auth0.com/api/v2/clients");
@@ -251,7 +251,7 @@ namespace Alethic.Auth0.Operator.Tests
             var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
             var breaker = new Auth0CircuitBreaker(new CircuitBreakerOptions { DefaultOpenDuration = TimeSpan.FromMinutes(1) }, time);
             var stub = new StubHandler { Respond = _ => TooManyRequests() };
-            using var client = new HttpClient(new Auth0RateLimitingHandler(null, breaker, stub));
+            using var client = new HttpClient(new Auth0RateLimitingHandler(null, breaker, null, stub));
 
             // first request reaches Auth0 and receives the 429 back
             var response = await client.GetAsync("https://tenant.us.auth0.com/api/v2/clients");

--- a/src/Alethic.Auth0.Operator.Tests/Auth0RatePacerTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Auth0RatePacerTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Net;
+using System.Net.Http;
+
+using Alethic.Auth0.Operator.Options;
+using Alethic.Auth0.Operator.RateLimiting;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests
+{
+
+    [TestClass]
+    public class Auth0RatePacerTests
+    {
+
+        sealed class FakeTimeProvider : TimeProvider
+        {
+
+            DateTimeOffset _now;
+
+            public FakeTimeProvider(DateTimeOffset now)
+            {
+                _now = now;
+            }
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            public void Advance(TimeSpan by) => _now += by;
+
+        }
+
+        static HttpResponseMessage Response(long? remaining = null, long? resetEpochSeconds = null)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            if (remaining is { } r)
+                response.Headers.Add("x-ratelimit-remaining", r.ToString());
+            if (resetEpochSeconds is { } s)
+                response.Headers.Add("x-ratelimit-reset", s.ToString());
+            return response;
+        }
+
+        [TestMethod]
+        public void NoRecordedBudget_NoDelay()
+        {
+            var pacer = new Auth0RatePacer(new PacingOptions());
+            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+        }
+
+        [TestMethod]
+        public void BudgetAboveThreshold_NoDelay()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
+
+            pacer.Record("tenant.us.auth0.com", Response(remaining: 50, resetEpochSeconds: 60));
+
+            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+        }
+
+        [TestMethod]
+        public void BudgetAtThreshold_SpreadsRemainingUntilReset()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10, MaxRequestDelay = TimeSpan.FromMinutes(1) }, time);
+
+            // 10 requests left, 60 seconds until refill: pace at one request per 6 seconds
+            pacer.Record("tenant.us.auth0.com", Response(remaining: 10, resetEpochSeconds: 60));
+
+            Assert.AreEqual(TimeSpan.FromSeconds(6), pacer.GetDelay("tenant.us.auth0.com"));
+        }
+
+        [TestMethod]
+        public void ExhaustedBudget_DelayCappedAtMaxRequestDelay()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10, MaxRequestDelay = TimeSpan.FromSeconds(10) }, time);
+
+            // 0 remaining with a 60s reset would want a 60s delay; the cap bounds it
+            pacer.Record("tenant.us.auth0.com", Response(remaining: 0, resetEpochSeconds: 60));
+
+            Assert.AreEqual(TimeSpan.FromSeconds(10), pacer.GetDelay("tenant.us.auth0.com"));
+        }
+
+        [TestMethod]
+        public void PastReset_NoDelay()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
+
+            pacer.Record("tenant.us.auth0.com", Response(remaining: 1, resetEpochSeconds: 60));
+            time.Advance(TimeSpan.FromSeconds(61));
+
+            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+        }
+
+        [TestMethod]
+        public void BudgetIsPerHost()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
+
+            pacer.Record("a.us.auth0.com", Response(remaining: 1, resetEpochSeconds: 60));
+
+            Assert.AreNotEqual(TimeSpan.Zero, pacer.GetDelay("a.us.auth0.com"));
+            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("b.us.auth0.com"));
+        }
+
+        [TestMethod]
+        public void ResponseWithoutHeaders_Ignored()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
+
+            pacer.Record("tenant.us.auth0.com", Response(remaining: 1, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com", Response());
+
+            // the headerless response must not clobber the recorded budget
+            Assert.AreNotEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+        }
+
+        [TestMethod]
+        public void NewerBudget_ReplacesOlder()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
+
+            pacer.Record("tenant.us.auth0.com", Response(remaining: 1, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com", Response(remaining: 50, resetEpochSeconds: 60));
+
+            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+        }
+
+    }
+
+}

--- a/src/Alethic.Auth0.Operator/Options/RateLimitOptions.cs
+++ b/src/Alethic.Auth0.Operator/Options/RateLimitOptions.cs
@@ -43,6 +43,38 @@ namespace Alethic.Auth0.Operator.Options
         /// </summary>
         public CircuitBreakerOptions CircuitBreaker { get; set; } = new();
 
+        /// <summary>
+        /// Configuration of adaptive request pacing driven by Auth0's reported rate limit budget.
+        /// </summary>
+        public PacingOptions Pacing { get; set; } = new();
+
+    }
+
+    /// <summary>
+    /// Configuration for adaptive request pacing. Auth0 reports the remaining rate limit budget and its reset
+    /// time on every response; once the remaining budget falls to the threshold, outbound requests are delayed
+    /// so the rest of the budget is spread across the time until the reset — consumption slows to Auth0's
+    /// refill rate instead of draining the bucket.
+    /// </summary>
+    public class PacingOptions
+    {
+
+        /// <summary>
+        /// Whether adaptive pacing is applied.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// The remaining budget at or below which pacing begins. Above this, requests flow unpaced.
+        /// </summary>
+        public int RemainingThreshold { get; set; } = 10;
+
+        /// <summary>
+        /// Upper bound on the delay applied to a single request, so a nearly empty bucket with a distant reset
+        /// cannot stall a reconcile slot indefinitely; beyond it, the circuit breaker is the backstop.
+        /// </summary>
+        public TimeSpan MaxRequestDelay { get; set; } = TimeSpan.FromSeconds(10);
+
     }
 
     /// <summary>

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0HttpClientProvider.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0HttpClientProvider.cs
@@ -53,11 +53,12 @@ namespace Alethic.Auth0.Operator.RateLimiting
                     }));
 
             var breaker = options.CircuitBreaker.Enabled ? new Auth0CircuitBreaker(options.CircuitBreaker) : null;
+            var pacer = options.Pacing.Enabled ? new Auth0RatePacer(options.Pacing) : null;
 
-            if (limiter is null && breaker is null)
+            if (limiter is null && breaker is null && pacer is null)
                 return new HttpClient(transport);
 
-            return new HttpClient(new Auth0RateLimitingHandler(limiter, breaker, transport));
+            return new HttpClient(new Auth0RateLimitingHandler(limiter, breaker, pacer, transport));
         }
 
     }

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
@@ -10,25 +10,29 @@ namespace Alethic.Auth0.Operator.RateLimiting
 
     /// <summary>
     /// <see cref="DelegatingHandler"/> that gates every outgoing Auth0 Management API request through a rate limiter
-    /// before it is sent, and trips the per-domain circuit breaker on any 429 response so that no further requests
-    /// reach that domain until the server-reported rate limit reset.
+    /// before it is sent, paces requests down to Auth0's refill rate as the reported budget depletes, and trips the
+    /// per-domain circuit breaker on any 429 response so that no further requests reach that domain until the
+    /// server-reported rate limit reset.
     /// </summary>
     sealed class Auth0RateLimitingHandler : DelegatingHandler
     {
 
         readonly PartitionedRateLimiter<HttpRequestMessage>? _limiter;
         readonly Auth0CircuitBreaker? _breaker;
+        readonly Auth0RatePacer? _pacer;
 
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="limiter"></param>
         /// <param name="breaker"></param>
+        /// <param name="pacer"></param>
         /// <param name="innerHandler"></param>
-        public Auth0RateLimitingHandler(PartitionedRateLimiter<HttpRequestMessage>? limiter, Auth0CircuitBreaker? breaker, HttpMessageHandler innerHandler)
+        public Auth0RateLimitingHandler(PartitionedRateLimiter<HttpRequestMessage>? limiter, Auth0CircuitBreaker? breaker, Auth0RatePacer? pacer, HttpMessageHandler innerHandler)
         {
             _limiter = limiter;
             _breaker = breaker;
+            _pacer = pacer;
             InnerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
         }
 
@@ -47,7 +51,14 @@ namespace Alethic.Auth0.Operator.RateLimiting
                     throw new HttpRequestException("Auth0 Management API client-side rate limit queue is full; backing off.");
             }
 
+            // when the reported budget is low, slow down to Auth0's refill rate instead of draining the bucket;
+            // holding the request (and thereby its reconcile slot) is the intended backpressure
+            if (_pacer?.GetDelay(host) is { } delay && delay > TimeSpan.Zero)
+                await Task.Delay(delay, cancellationToken);
+
             var response = await base.SendAsync(request, cancellationToken);
+
+            _pacer?.Record(host, response);
 
             // a 429 opens the circuit for the whole domain; the response still flows back so the SDK surfaces
             // its rate limit error to the requesting reconcile, which reschedules on its own. a successful

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0RatePacer.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0RatePacer.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+
+using Alethic.Auth0.Operator.Options;
+
+namespace Alethic.Auth0.Operator.RateLimiting
+{
+
+    /// <summary>
+    /// Adaptive per-domain pacing of Auth0 Management API requests. Every response's rate limit headers are
+    /// recorded, and once the reported remaining budget falls to the configured threshold, outbound requests are
+    /// delayed just enough to spread the remaining budget across the time until the server-reported reset — so
+    /// consumption slows to Auth0's refill rate instead of draining the bucket and tripping the circuit breaker.
+    /// </summary>
+    public sealed class Auth0RatePacer
+    {
+
+        readonly record struct Budget(long Remaining, DateTimeOffset Reset);
+
+        readonly PacingOptions _options;
+        readonly TimeProvider _time;
+        readonly ConcurrentDictionary<string, Budget> _budgets = new();
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="time"></param>
+        public Auth0RatePacer(PacingOptions options, TimeProvider? time = null)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _time = time ?? TimeProvider.System;
+        }
+
+        /// <summary>
+        /// Records the rate limit budget reported by a response. Responses without both a parseable remaining
+        /// count and reset time are ignored.
+        /// </summary>
+        /// <param name="host"></param>
+        /// <param name="response"></param>
+        public void Record(string host, HttpResponseMessage response)
+        {
+            if (TryGetHeaderValue(response, "x-ratelimit-remaining", out var remaining) == false)
+                return;
+
+            if (TryGetHeaderValue(response, "x-ratelimit-reset", out var resetEpochSeconds) == false)
+                return;
+
+            _budgets[host] = new Budget(remaining, DateTimeOffset.FromUnixTimeSeconds(resetEpochSeconds));
+        }
+
+        /// <summary>
+        /// Computes the delay to apply before the next request to <paramref name="host"/>: zero while the
+        /// reported budget is above the threshold or already reset, otherwise the time until reset divided by
+        /// the remaining budget, bounded by the configured maximum per-request delay.
+        /// </summary>
+        /// <param name="host"></param>
+        public TimeSpan GetDelay(string host)
+        {
+            if (_budgets.TryGetValue(host, out var budget) == false)
+                return TimeSpan.Zero;
+
+            var now = _time.GetUtcNow();
+            if (budget.Reset <= now)
+            {
+                // the bucket has refilled; forget the stale budget unless a newer one raced in
+                _budgets.TryRemove(new System.Collections.Generic.KeyValuePair<string, Budget>(host, budget));
+                return TimeSpan.Zero;
+            }
+
+            if (budget.Remaining > _options.RemainingThreshold)
+                return TimeSpan.Zero;
+
+            var delay = (budget.Reset - now) / Math.Max(budget.Remaining, 1);
+            if (delay > _options.MaxRequestDelay)
+                delay = _options.MaxRequestDelay;
+
+            return delay;
+        }
+
+        static bool TryGetHeaderValue(HttpResponseMessage response, string name, out long value)
+        {
+            value = 0;
+
+            if (response.Headers.TryGetValues(name, out var values) == false)
+                return false;
+
+            return long.TryParse(values.FirstOrDefault(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Summary

Labs on 1.4.8-pre.9 showed the intended failure mode working — the startup burst drained the reported budget to zero and the preemptive circuit open kicked in with zero actual 429s — but that converts the tail of every burst into rescheduled reconciles. This adds the smoother layer in front: adaptive pacing.

`Auth0RatePacer` records `x-ratelimit-remaining` / `x-ratelimit-reset` per domain from every response. Once the remaining budget falls to a threshold (default 10), each outbound request is delayed by `(reset − now) / remaining`, bounded by a per-request maximum (default 10s) — consumption slows to Auth0''s actual refill rate instead of draining the bucket. Holding the request (and thereby its reconcile slot) is the intended backpressure: reconciles finish late instead of failing fast and rescheduling.

Layering in the handler, in order: circuit-open fail-fast → token bucket → adaptive delay → send → record headers → breaker trip on 429 / preemptive open on exhaustion. The breaker remains the backstop when pacing can''t keep up (e.g. another consumer of the same tenant burns the budget between our responses).

## Configuration

New `options.rateLimit.pacing` block in the chart (`enabled`, `remainingThreshold`, `maxRequestDelay`), mapped to `Auth0__Operator__RateLimit__Pacing__*`. Enabled by default; independent of the token bucket and breaker switches.

## Tests

9 new pacer tests: no-budget/above-threshold/past-reset produce zero delay, the spread math (10 remaining over 60s → 6s/request), the max-delay cap on an exhausted budget, per-host isolation, headerless responses not clobbering a recorded budget, and newer budgets replacing older ones. Full suite: 390 passed.