### PR TITLE
Parse custom text screens from the SDK's JsonElement shape

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3ResourceServerCustomTextNeedsUpdateTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3ResourceServerCustomTextNeedsUpdateTests.cs
@@ -126,6 +126,39 @@ namespace Alethic.Auth0.Operator.Tests
         }
 
         [TestMethod]
+        public void CustomText_JsonElementReadback_ParsesAndConverges()
+        {
+            // the SDK deserializes the untyped screens as JsonElement values; parsing them wrongly made the
+            // read-back empty and re-issued the full-replace write every cycle in labs
+            var apiShape = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(
+                """{"login":{"description":"Log in to ${companyName} to start exploring!","title":"Welcome to Sweep!"}}""");
+
+            var last = V2alpha3CustomTextController.FromApiScreens(apiShape);
+
+            Assert.IsNotNull(last);
+            Assert.AreEqual("Welcome to Sweep!", last["login"]["title"]);
+
+            var conf = new Dictionary<string, V2alpha3CustomTextScreen>
+            {
+                ["login"] = Screen(("description", "Log in to ${companyName} to start exploring!"), ("title", "Welcome to Sweep!")),
+            };
+
+            Assert.IsFalse(V2alpha3CustomTextController.ScreensRequireUpdate(conf, last));
+        }
+
+        [TestMethod]
+        public void CustomText_JsonElementReadback_ChangedValueStillDetected()
+        {
+            var apiShape = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(
+                """{"login":{"title":"Old Title"}}""");
+
+            var last = V2alpha3CustomTextController.FromApiScreens(apiShape);
+            var conf = new Dictionary<string, V2alpha3CustomTextScreen> { ["login"] = Screen(("title", "New Title")) };
+
+            Assert.IsTrue(V2alpha3CustomTextController.ScreensRequireUpdate(conf, last));
+        }
+
+        [TestMethod]
         public void ResourceServer_ScopesReordered_NoUpdate()
         {
             // scopes are a set keyed by value; Auth0 returning them in a different order is not drift

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3CustomTextController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3CustomTextController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,17 +33,37 @@ namespace Alethic.Auth0.Operator.Controllers
         IEntityController<V2alpha3CustomText>
     {
 
-        static V2alpha3CustomTextScreen FromApiScreen(Dictionary<string, object> source)
+        /// <summary>
+        /// Converts a single screen from the API's untyped shape. The SDK deserializes the untyped screen values
+        /// as <see cref="JsonElement"/> objects; a plain dictionary is also accepted for safety. Returns null for
+        /// values that are not object-shaped.
+        /// </summary>
+        internal static V2alpha3CustomTextScreen? FromApiScreen(object? source)
         {
-            var screen = new V2alpha3CustomTextScreen();
+            if (source is JsonElement element && element.ValueKind == JsonValueKind.Object)
+            {
+                var screen = new V2alpha3CustomTextScreen();
 
-            foreach (var kvp in source)
-                screen[kvp.Key] = kvp.Value?.ToString() ?? string.Empty;
+                foreach (var property in element.EnumerateObject())
+                    screen[property.Name] = property.Value.ValueKind == JsonValueKind.String ? property.Value.GetString() ?? string.Empty : property.Value.ToString();
 
-            return screen;
+                return screen;
+            }
+
+            if (source is Dictionary<string, object> dict)
+            {
+                var screen = new V2alpha3CustomTextScreen();
+
+                foreach (var kvp in dict)
+                    screen[kvp.Key] = kvp.Value?.ToString() ?? string.Empty;
+
+                return screen;
+            }
+
+            return null;
         }
 
-        static Dictionary<string, V2alpha3CustomTextScreen>? FromApiScreens(Dictionary<string, object>? source)
+        internal static Dictionary<string, V2alpha3CustomTextScreen>? FromApiScreens(Dictionary<string, object>? source)
         {
             if (source is null)
                 return null;
@@ -50,8 +71,8 @@ namespace Alethic.Auth0.Operator.Controllers
             var result = new Dictionary<string, V2alpha3CustomTextScreen>();
 
             foreach (var kvp in source)
-                if (kvp.Value is Dictionary<string, object> screenDict)
-                    result[kvp.Key] = FromApiScreen(screenDict);
+                if (FromApiScreen(kvp.Value) is { } screen)
+                    result[kvp.Key] = screen;
 
             return result;
         }


### PR DESCRIPTION
## Summary

Observed in labs: "Set custom text for a specific prompt" posting to the Auth0 logs on every reconcile cycle. The CustomText CRs showed the cause directly — `spec.conf.screens` populated, `status.lastConf.screens` **empty**.

`FromApiScreens` only accepted screen values typed `Dictionary<string, object>`, but the SDK deserializes the untyped screens response as `JsonElement` values — so every screen was silently dropped, the read-back was always empty, and the full-replace drift gate (correctly requiring exact equality) saw permanent drift and re-wrote every cycle.

`FromApiScreen` now parses `JsonElement` objects (string values via `GetString`, anything else stringified), keeping the dictionary path as a fallback. The read-back now reflects what Auth0 actually returns, so the gate converges after one write.

## Tests

Two new tests driving `FromApiScreens` with the SDK''s literal runtime shape (`JsonSerializer.Deserialize<Dictionary<string, object>>` of the exact labs payload): identical spec → no write; changed value → write still detected. Full suite: 395 passed.