### PR TITLE
Fix all nullable reference warnings

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3ClientControllerMappingTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3ClientControllerMappingTests.cs
@@ -145,7 +145,7 @@ namespace Alethic.Auth0.Operator.Tests
                 SecretEncoded = true,
                 LifetimeInSeconds = 3600,
                 Alg = new SigningAlgorithmEnum(SigningAlgorithmEnum.Values.Rs256),
-                Scopes = new Dictionary<string, object>
+                Scopes = new Dictionary<string, object?>
                 {
                     ["read:data"] = "allow",
                 },

--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3ConnectionControllerMappingTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3ConnectionControllerMappingTests.cs
@@ -80,7 +80,7 @@ namespace Alethic.Auth0.Operator.Tests
                 Id = "con_metadata",
                 Name = "x",
                 Strategy = ConnectionResponseContentAuth0Strategy.Values.Auth0,
-                Metadata = new System.Collections.Generic.Dictionary<string, string> { ["env"] = "prod" },
+                Metadata = new System.Collections.Generic.Dictionary<string, string?> { ["env"] = "prod" },
             };
 
             var result = V2alpha3ConnectionController.FromApi(source);
@@ -231,7 +231,7 @@ namespace Alethic.Auth0.Operator.Tests
         {
             var source = new ConnectionOptionsGitHub
             {
-                UpstreamParams = global::Auth0.ManagementApi.Core.Optional<Dictionary<string, ConnectionUpstreamAdditionalProperties>?>.Of(
+                UpstreamParams = global::Auth0.ManagementApi.Core.Optional<Dictionary<string, ConnectionUpstreamAdditionalProperties?>?>.Of(
                     new Dictionary<string, ConnectionUpstreamAdditionalProperties?>
                     {
                         ["login_hint"] = ConnectionUpstreamAdditionalProperties.FromConnectionUpstreamValue(
@@ -253,7 +253,7 @@ namespace Alethic.Auth0.Operator.Tests
             var source = new ConnectionOptionsPingFederate
             {
                 PingFederateBaseUrl = "https://pingfed.example",
-                UpstreamParams = global::Auth0.ManagementApi.Core.Optional<Dictionary<string, ConnectionUpstreamAdditionalProperties>?>.Of(
+                UpstreamParams = global::Auth0.ManagementApi.Core.Optional<Dictionary<string, ConnectionUpstreamAdditionalProperties?>?>.Of(
                     new Dictionary<string, ConnectionUpstreamAdditionalProperties?>
                     {
                         ["resource"] = ConnectionUpstreamAdditionalProperties.FromConnectionUpstreamAlias(
@@ -274,7 +274,7 @@ namespace Alethic.Auth0.Operator.Tests
         {
             var source = new ConnectionOptionsFacebook
             {
-                UpstreamParams = new Dictionary<string, ConnectionUpstreamAdditionalProperties?>
+                UpstreamParams = new Dictionary<string, ConnectionUpstreamAdditionalProperties>
                 {
                     ["prompt"] = ConnectionUpstreamAdditionalProperties.FromConnectionUpstreamAlias(
                         new ConnectionUpstreamAlias { Alias = ConnectionUpstreamAliasEnum.Prompt }),
@@ -380,9 +380,10 @@ namespace Alethic.Auth0.Operator.Tests
 
             var result = InvokeConvert(source);
 
-            Assert.IsNotNull(result.Spec.Conf?.Options?.Saml?.DecryptionKey);
-            Assert.AreEqual("pem-value", result.Spec.Conf.Options.Saml.DecryptionKey.PrivateKey);
-            Assert.IsNull(result.Spec.Conf.Options.Saml.DecryptionKey.KeyPair);
+            var decryptionKey = result.Spec.Conf?.Options?.Saml?.DecryptionKey;
+            Assert.IsNotNull(decryptionKey);
+            Assert.AreEqual("pem-value", decryptionKey.PrivateKey);
+            Assert.IsNull(decryptionKey.KeyPair);
         }
 
         [TestMethod]

--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3ResourceServerControllerMappingTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3ResourceServerControllerMappingTests.cs
@@ -379,9 +379,11 @@ namespace Alethic.Auth0.Operator.Tests
             Assert.IsTrue(req.EnforcePolicies);
             Assert.AreEqual(ResourceServerConsentPolicyEnum.Values.TransactionalAuthorizationWithMfa, req.ConsentPolicy.Value?.Value);
             Assert.AreEqual("pol_123", req.AuthorizationPolicy.Value!.PolicyId);
+            Assert.IsNotNull(req.SubjectTypeAuthorization);
             Assert.AreEqual<string>(ResourceServerSubjectTypeAuthorizationClientPolicyEnum.Values.RequireClientGrant.ToString(), req.SubjectTypeAuthorization.Client!.Policy!.Value.ToString());
             Assert.AreEqual<string>(ResourceServerSubjectTypeAuthorizationUserPolicyEnum.Values.AllowAll.ToString(), req.SubjectTypeAuthorization.User!.Policy!.Value.ToString());
-            Assert.AreEqual(1, req.Scopes!.Count());
+            Assert.IsNotNull(req.Scopes);
+            Assert.AreEqual(1, req.Scopes.Count());
             Assert.AreEqual("read:data", req.Scopes.First().Value);
         }
 

--- a/src/Alethic.Auth0.Operator.Tests/V2alpha3ResourceServerCustomTextNeedsUpdateTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/V2alpha3ResourceServerCustomTextNeedsUpdateTests.cs
@@ -130,7 +130,7 @@ namespace Alethic.Auth0.Operator.Tests
         {
             // the SDK deserializes the untyped screens as JsonElement values; parsing them wrongly made the
             // read-back empty and re-issued the full-replace write every cycle in labs
-            var apiShape = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(
+            var apiShape = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(
                 """{"login":{"description":"Log in to ${companyName} to start exploring!","title":"Welcome to Sweep!"}}""");
 
             var last = V2alpha3CustomTextController.FromApiScreens(apiShape);
@@ -149,7 +149,7 @@ namespace Alethic.Auth0.Operator.Tests
         [TestMethod]
         public void CustomText_JsonElementReadback_ChangedValueStillDetected()
         {
-            var apiShape = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(
+            var apiShape = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(
                 """{"login":{"title":"Old Title"}}""");
 
             var last = V2alpha3CustomTextController.FromApiScreens(apiShape);

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ClientController.cs
@@ -73,7 +73,7 @@ namespace Alethic.Auth0.Operator.Controllers
             OrganizationRequireBehavior = FromApi(source.OrganizationRequireBehavior),
             OrganizationUsage = FromApi(source.OrganizationUsage),
             RefreshToken = source.RefreshToken.IsDefined && source.RefreshToken.Value is { } refreshToken ? FromApi(refreshToken) : null,
-            SigningKeys = source.SigningKeys.IsDefined ? source.SigningKeys.Value?.Select(FromApi).ToArray() : null,
+            SigningKeys = source.SigningKeys.IsDefined ? source.SigningKeys.Value?.Select(i => FromApi(i)).ToArray() : null,
             TokenEndpointAuthMethod = FromApi(source.TokenEndpointAuthMethod),
         };
 
@@ -105,7 +105,7 @@ namespace Alethic.Auth0.Operator.Controllers
             RotationType = FromApi(source.RotationType),
             TokenLifetime = source.TokenLifetime,
             IdleTokenLifetime = source.IdleTokenLifetime,
-            Policies = source.Policies.IsDefined && source.Policies.Value is { } policies ? policies.Select(FromApi).ToArray() : null,
+            Policies = source.Policies.IsDefined && source.Policies.Value is { } policies ? policies.Select(i => FromApi(i)).ToArray() : null,
         };
 
         [return: NotNullIfNotNull(nameof(source))]
@@ -518,7 +518,6 @@ namespace Alethic.Auth0.Operator.Controllers
             ExternalUrl = source.ExternalUrl is { } externalUrl ? FromApi(externalUrl) : null,
         };
 
-        [return: NotNullIfNotNull(nameof(source))]
         internal static string[]? FromApi(ClientAddonSharePointExternalUrl? source)
         {
             if (source is null)
@@ -699,11 +698,18 @@ namespace Alethic.Auth0.Operator.Controllers
             Include = source.Include,
         };
 
-        static ClientDefaultOrganization ToApi(V2alpha3ClientDefaultOrganization source) => new()
+        static ClientDefaultOrganization ToApi(V2alpha3ClientDefaultOrganization source)
         {
-            OrganizationId = source.OrganizationId,
-            Flows = source.Flows?.Select(ToApi).ToArray(),
-        };
+            var target = new ClientDefaultOrganization
+            {
+                OrganizationId = source.OrganizationId ?? throw new InvalidOperationException("DefaultOrganization is missing an organization ID."),
+            };
+
+            if (source.Flows is { } flows)
+                target.Flows = flows.Select(ToApi).ToArray();
+
+            return target;
+        }
 
         static ClientDefaultOrganizationFlowsEnum ToApi(V2alpha3ClientDefaultOrganizationFlowsEnum source) => source switch
         {
@@ -780,17 +786,20 @@ namespace Alethic.Auth0.Operator.Controllers
 
         static ClientAddonRms ToApi(V2alpha3ClientAddonRms source) => new()
         {
-            Url = source.Url,
+            // required by the SDK but optional in the CRD model; shared with the conversion webhook, so pass through unchecked
+            Url = source.Url!,
         };
 
         static ClientAddonMscrm ToApi(V2alpha3ClientAddonMscrm source) => new()
         {
-            Url = source.Url,
+            // required by the SDK but optional in the CRD model; shared with the conversion webhook, so pass through unchecked
+            Url = source.Url!,
         };
 
         static ClientAddonSlack ToApi(V2alpha3ClientAddonSlack source) => new()
         {
-            Team = source.Team,
+            // required by the SDK but optional in the CRD model; shared with the conversion webhook, so pass through unchecked
+            Team = source.Team!,
         };
 
         static ClientAddonSentry ToApi(V2alpha3ClientAddonSentry source) => new()
@@ -872,9 +881,10 @@ namespace Alethic.Auth0.Operator.Controllers
 
         static ClientAddonLayer ToApi(V2alpha3ClientAddonLayer source) => new()
         {
-            ProviderId = source.ProviderId,
-            KeyId = source.KeyId,
-            PrivateKey = source.PrivateKey,
+            // required by the SDK but optional in the CRD model; shared with the conversion webhook, so pass through unchecked
+            ProviderId = source.ProviderId!,
+            KeyId = source.KeyId!,
+            PrivateKey = source.PrivateKey!,
             Principal = source.Principal,
             Expiration = source.Expiration,
         };
@@ -964,11 +974,19 @@ namespace Alethic.Auth0.Operator.Controllers
                 target.Policies = policies.Select(ToApi).ToList();
         }
 
-        static ClientRefreshTokenPolicy ToApi(V2alpha3ClientRefreshTokenPolicy source) => new()
+        static ClientRefreshTokenPolicy ToApi(V2alpha3ClientRefreshTokenPolicy source)
         {
-            Audience = source.Audience,
-            Scope = source.Scope?.ToList(),
-        };
+            var target = new ClientRefreshTokenPolicy
+            {
+                // required by the SDK but optional in the CRD model; shared with the conversion webhook, so pass through unchecked
+                Audience = source.Audience!,
+            };
+
+            if (source.Scope is { } scope)
+                target.Scope = scope.ToList();
+
+            return target;
+        }
 
         internal static void ApplyToApi(V2alpha3ClientOidcBackchannelLogoutInitiators source, ClientOidcBackchannelLogoutInitiators target)
         {
@@ -1380,7 +1398,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
             var self = await api.Clients.CreateAsync(req, null, cancellationToken);
             Logger.LogInformation("{EntityTypeName} successfully created client in Auth0 with ID: {ClientId} and name: {ClientName}", EntityTypeName, self.ClientId, conf.Name);
-            return self.ClientId;
+            return self.ClientId ?? throw new InvalidOperationException("Create response missing client ID.");
         }
 
         /// <summary>

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ClientGrantController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ClientGrantController.cs
@@ -232,7 +232,7 @@ namespace Alethic.Auth0.Operator.Controllers
             if (self is null)
                 throw new InvalidOperationException();
 
-            return self.Id;
+            return self.Id ?? throw new InvalidOperationException("Create response missing client grant ID.");
         }
 
         /// <inheritdoc />

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionController.cs
@@ -3209,10 +3209,13 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static ConnectionOptionsOidcMetadata ToApi(V2alpha3ConnectionOptionsOidcMetadata source)
         {
-            return new ConnectionOptionsOidcMetadata
+            var target = new ConnectionOptionsOidcMetadata
             {
+                // required by the SDK but optional in the CRD model; shared with the conversion webhook, so pass through unchecked
+                AuthorizationEndpoint = source.AuthorizationEndpoint!,
+                Issuer = source.Issuer!,
+                JwksUri = source.JwksUri!,
                 AcrValuesSupported = source.AcrValuesSupported,
-                AuthorizationEndpoint = source.AuthorizationEndpoint,
                 ClaimTypesSupported = source.ClaimTypesSupported,
                 ClaimsLocalesSupported = source.ClaimsLocalesSupported,
                 ClaimsParameterSupported = source.ClaimsParameterSupported,
@@ -3223,9 +3226,6 @@ namespace Alethic.Auth0.Operator.Controllers
                 GrantTypesSupported = source.GrantTypesSupported,
                 IdTokenEncryptionAlgValuesSupported = source.IdTokenEncryptionAlgValuesSupported,
                 IdTokenEncryptionEncValuesSupported = source.IdTokenEncryptionEncValuesSupported,
-                IdTokenSigningAlgValuesSupported = source.IdTokenSigningAlgValuesSupported,
-                Issuer = source.Issuer,
-                JwksUri = source.JwksUri,
                 OpPolicyUri = source.OpPolicyUri,
                 OpTosUri = source.OpTosUri,
                 RegistrationEndpoint = source.RegistrationEndpoint,
@@ -3249,6 +3249,11 @@ namespace Alethic.Auth0.Operator.Controllers
                 UserinfoSigningAlgValuesSupported = source.UserinfoSigningAlgValuesSupported,
                 ScopesSupported = source.ScopesSupported is { } scopesSupported ? Optional<IEnumerable<string>?>.Of(scopesSupported) : default,
             };
+
+            if (source.IdTokenSigningAlgValuesSupported is { } idTokenSigningAlgValuesSupported)
+                target.IdTokenSigningAlgValuesSupported = idTokenSigningAlgValuesSupported;
+
+            return target;
         }
 
         internal static Optional<IEnumerable<ConnectionIdTokenSignedResponseAlgEnum>?> ToApi(IEnumerable<V2alpha3ConnectionIdTokenSignedResponseAlgEnum> source)
@@ -3502,7 +3507,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static ConnectionOptionsAzureAd ToApi(V2alpha3ConnectionOptionsAzureAd source)
         {
-            var target = new ConnectionOptionsAzureAd { ClientId = source.ClientId, ClientSecret = source.ClientSecret };
+            var target = new ConnectionOptionsAzureAd { ClientId = source.ClientId!, ClientSecret = source.ClientSecret };
             target.ApiEnableUsers = source.ApiEnableUsers;
             target.AppDomain = source.AppDomain;
             target.AppId = source.AppId;
@@ -3878,7 +3883,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static ConnectionOptionsGoogleApps ToApi(V2alpha3ConnectionOptionsGoogleApps source)
         {
-            var target = new ConnectionOptionsGoogleApps { ClientId = source.ClientId, ClientSecret = source.ClientSecret };
+            var target = new ConnectionOptionsGoogleApps { ClientId = source.ClientId!, ClientSecret = source.ClientSecret };
             if (source.Scope is { } scope)
                 target.Scope = scope;
             target.Domain = source.Domain;
@@ -4260,7 +4265,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static ConnectionOptionsOidc ToApi(V2alpha3ConnectionOptionsOidc source)
         {
-            var target = new ConnectionOptionsOidc { ClientId = source.ClientId, ClientSecret = source.ClientSecret };
+            var target = new ConnectionOptionsOidc { ClientId = source.ClientId!, ClientSecret = source.ClientSecret };
             target.DiscoveryUrl = source.DiscoveryUrl;
             target.AuthorizationEndpoint = source.AuthorizationEndpoint;
             target.TokenEndpoint = source.TokenEndpoint;
@@ -4304,7 +4309,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static ConnectionOptionsOkta ToApi(V2alpha3ConnectionOptionsOkta source)
         {
-            var target = new ConnectionOptionsOkta { ClientId = source.ClientId, ClientSecret = source.ClientSecret };
+            var target = new ConnectionOptionsOkta { ClientId = source.ClientId!, ClientSecret = source.ClientSecret };
             target.Domain = source.Domain;
             target.AuthorizationEndpoint = source.AuthorizationEndpoint;
             target.TokenEndpoint = source.TokenEndpoint;
@@ -4368,7 +4373,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static ConnectionOptionsPingFederate ToApi(V2alpha3ConnectionOptionsPingFederate source)
         {
-            var target = new ConnectionOptionsPingFederate { PingFederateBaseUrl = source.PingFederateBaseUrl };
+            var target = new ConnectionOptionsPingFederate { PingFederateBaseUrl = source.PingFederateBaseUrl! };
             target.SignInEndpoint = source.SignInEndpoint;
             target.EntityId = source.EntityId;
             target.Cert = source.Cert;
@@ -8816,7 +8821,7 @@ namespace Alethic.Auth0.Operator.Controllers
                 throw new InvalidOperationException();
 
             Logger.LogInformation("{EntityTypeName} successfully created connection in Auth0 with ID: {ConnectionId}, name: {ConnectionName} and strategy: {Strategy}", EntityTypeName, self.Id, conf.Name, conf.Strategy);
-            return self.Id;
+            return self.Id ?? throw new InvalidOperationException("Create response missing connection ID.");
         }
 
         /// <inheritdoc />

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3CustomTextController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3CustomTextController.cs
@@ -63,7 +63,7 @@ namespace Alethic.Auth0.Operator.Controllers
             return null;
         }
 
-        internal static Dictionary<string, V2alpha3CustomTextScreen>? FromApiScreens(Dictionary<string, object>? source)
+        internal static Dictionary<string, V2alpha3CustomTextScreen>? FromApiScreens(Dictionary<string, object?>? source)
         {
             if (source is null)
                 return null;
@@ -121,9 +121,9 @@ namespace Alethic.Auth0.Operator.Controllers
             return false;
         }
 
-        static Dictionary<string, object> ToApiScreens(Dictionary<string, V2alpha3CustomTextScreen> source)
+        static Dictionary<string, object?> ToApiScreens(Dictionary<string, V2alpha3CustomTextScreen> source)
         {
-            var result = new Dictionary<string, object>();
+            var result = new Dictionary<string, object?>();
 
             foreach (var kvp in source)
             {

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ResourceServerController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ResourceServerController.cs
@@ -44,7 +44,7 @@ namespace Alethic.Auth0.Operator.Controllers
             Id = source.Id,
             Identifier = source.Identifier,
             Name = source.Name,
-            Scopes = source.Scopes?.Select(FromApi).ToArray(),
+            Scopes = source.Scopes?.Select(i => FromApi(i)).ToArray(),
             SigningAlgorithm = FromApi(source.SigningAlg),
             SigningSecret = source.SigningSecret,
             TokenLifetime = source.TokenLifetime,
@@ -69,7 +69,7 @@ namespace Alethic.Auth0.Operator.Controllers
             Id = source.Id,
             Identifier = source.Identifier,
             Name = source.Name,
-            Scopes = source.Scopes?.Select(FromApi).ToArray(),
+            Scopes = source.Scopes?.Select(i => FromApi(i)).ToArray(),
             SigningAlgorithm = FromApi(source.SigningAlg),
             SigningSecret = source.SigningSecret,
             TokenLifetime = source.TokenLifetime,
@@ -240,7 +240,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static ResourceServerAuthorizationPolicy ToApi(V2alpha3ResourceServerAuthorizationPolicy source) => new()
         {
-            PolicyId = source.PolicyId,
+            PolicyId = source.PolicyId ?? throw new InvalidOperationException("AuthorizationPolicy is missing a policy ID."),
         };
 
         internal static ResourceServerSubjectTypeAuthorization ToApi(V2alpha3ResourceServerSubjectTypeAuthorization source) => new()
@@ -268,7 +268,7 @@ namespace Alethic.Auth0.Operator.Controllers
         internal static ResourceServerTokenEncryption ToApi(V2alpha3ResourceServerTokenEncryption source) => new()
         {
             Format = ToApi(source.Format ?? default),
-            EncryptionKey = source.EncryptionKey is { } key ? ToApi(key) : null,
+            EncryptionKey = source.EncryptionKey is { } key ? ToApi(key) : throw new InvalidOperationException("TokenEncryption is missing an encryption key."),
         };
 
         internal static ResourceServerTokenEncryptionKey ToApi(V2alpha3ResourceServerTokenEncryptionKey source) => new()
@@ -308,7 +308,7 @@ namespace Alethic.Auth0.Operator.Controllers
 
         internal static ResourceServerScope ToApi(V2alpha3ResourceServerScope source) => new()
         {
-            Value = source.Value,
+            Value = source.Value ?? throw new InvalidOperationException("Scope is missing a value."),
             Description = source.Description,
         };
 
@@ -476,7 +476,7 @@ namespace Alethic.Auth0.Operator.Controllers
             var req = new CreateResourceServerRequestContent { Identifier = conf.Identifier ?? throw new InvalidOperationException("Identifier is required.") };
             ApplyToApi(conf, req);
             var self = await api.ResourceServers.CreateAsync(req, null, cancellationToken);
-            return self.Id;
+            return self.Id ?? throw new InvalidOperationException("Create response missing resource server ID.");
         }
 
         /// <summary>

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3TenantController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3TenantController.cs
@@ -1314,13 +1314,14 @@ namespace Alethic.Auth0.Operator.Controllers
                 if (conf.Settings is { } newSettings && SettingsRequireUpdate(newSettings, FromApi(settings)))
                 {
                     // verify that no changes to enable_sso are being made
-                    if (newSettings.Flags != null && newSettings.Flags.EnableSso != null && settings.Flags.EnableSso != null && newSettings.Flags.EnableSso != settings.Flags.EnableSso)
+                    if (newSettings.Flags != null && newSettings.Flags.EnableSso != null && settings.Flags != null && settings.Flags.EnableSso != null && newSettings.Flags.EnableSso != settings.Flags.EnableSso)
                         throw new RetryException($"{EntityTypeName} {entity.Namespace()}/{entity.Name()}: updating the enable_sso flag is not allowed.");
 
                     // push update to Auth0
                     var req = new UpdateTenantSettingsRequestContent();
                     ApplyToApi(newSettings, req);
-                    req.Flags.EnableSso = null; // this can never be passed
+                    if (req.Flags != null)
+                        req.Flags.EnableSso = null; // this can never be passed
                     var res = await api.Tenants.Settings.UpdateAsync(req, cancellationToken: cancellationToken);
                     settings = await api.Tenants.Settings.GetAsync(new GetTenantSettingsRequestParameters() { }, cancellationToken: cancellationToken);
                 }

--- a/src/Alethic.Auth0.Operator/Converters/ClientConverter.cs
+++ b/src/Alethic.Auth0.Operator/Converters/ClientConverter.cs
@@ -283,11 +283,19 @@ namespace Alethic.Auth0.Operator.Converters
                 _ => throw new NotImplementedException(),
             };
 
-            static ClientDefaultOrganization ToApi(V2alpha3ClientDefaultOrganization source) => new()
+            static ClientDefaultOrganization ToApi(V2alpha3ClientDefaultOrganization source)
             {
-                OrganizationId = source.OrganizationId,
-                Flows = source.Flows?.Select(ToApi).ToArray(),
-            };
+                var target = new ClientDefaultOrganization
+                {
+                    // required by the SDK but optional in the CRD model; conversion must tolerate an absent value, so pass through unchecked
+                    OrganizationId = source.OrganizationId!,
+                };
+
+                if (source.Flows is { } flows)
+                    target.Flows = flows.Select(ToApi).ToArray();
+
+                return target;
+            }
 
             static ClientDefaultOrganizationFlowsEnum ToApi(V2alpha3ClientDefaultOrganizationFlowsEnum source) => source switch
             {


### PR DESCRIPTION
## Summary

Eliminates every CS8xxx nullable-reference warning (~50 across CS8601/02/03/04/19/20/25) from the solution — no `#pragma`, no `NoWarn`; the type or the flow is fixed at each site.

Recurring shapes and their fixes:

- **CS8619 on `Select(FromApi)`**: method-group conversion loses `[return: NotNullIfNotNull]`; converted to lambdas so flow analysis applies.
- **CS8825**: the SharePoint external-URL mapper's `NotNullIfNotNull` was a lie (the SDK `TryGet*` outs are nullable) — annotation removed; its only caller already accepts null.
- **CS8620 (CustomText)**: `FromApiScreens`/`ToApiScreens` signatures now match the SDK's actual `Dictionary<string, object?>` shapes instead of casting.
- **CS8601 (the big group)**: every one of these feeds an optional CRD field into a **`required` non-nullable** SDK member, so a guard cannot skip the assignment (CS9035). Split by reachability:
  - Mappers used only when building Auth0 requests now **throw a descriptive `InvalidOperationException`** (e.g. "DefaultOrganization is missing an organization ID.") — previously the null went to Auth0 and came back as an opaque 400.
  - Mappers reachable from **conversion webhooks** pass through with a commented `!` (16 sites): conversion must tolerate legitimately stored objects with absent values, and throwing there would wedge reads. Runtime behavior at these sites is unchanged.
- **CS8603**: the four `Create` methods now throw on a response missing its ID instead of returning null into `status.id`.
- **Test warnings**: dictionary type arguments corrected to the SDK's shapes; two `?.`-chain assertions restructured with `Assert.IsNotNull`; zero assertions weakened.

## Verification

`dotnet build Alethic.Auth0.Operator.slnx --no-incremental`: **0 CS8xxx warnings** (remaining warnings are the pre-existing MSTEST0037/NU1510 sets). Full suite: **395 passed** — now enforced on CI by #30.