### PR TITLE
Pace Auth0 requests per rate limit bucket and share connection enabled-clients reads

### DIFF
--- a/src/Alethic.Auth0.Operator.Tests/Auth0RatePacerTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/Auth0RatePacerTests.cs
@@ -30,13 +30,15 @@ namespace Alethic.Auth0.Operator.Tests
 
         }
 
-        static HttpResponseMessage Response(long? remaining = null, long? resetEpochSeconds = null)
+        static HttpResponseMessage Response(long? remaining = null, long? resetEpochSeconds = null, long? limit = null)
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
             if (remaining is { } r)
                 response.Headers.Add("x-ratelimit-remaining", r.ToString());
             if (resetEpochSeconds is { } s)
                 response.Headers.Add("x-ratelimit-reset", s.ToString());
+            if (limit is { } l)
+                response.Headers.Add("x-ratelimit-limit", l.ToString());
             return response;
         }
 
@@ -44,7 +46,7 @@ namespace Alethic.Auth0.Operator.Tests
         public void NoRecordedBudget_NoDelay()
         {
             var pacer = new Auth0RatePacer(new PacingOptions());
-            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+            Assert.AreEqual(TimeSpan.Zero, pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
         }
 
         [TestMethod]
@@ -53,9 +55,9 @@ namespace Alethic.Auth0.Operator.Tests
             var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
             var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
 
-            pacer.Record("tenant.us.auth0.com", Response(remaining: 50, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response(remaining: 50, resetEpochSeconds: 60));
 
-            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+            Assert.AreEqual(TimeSpan.Zero, pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
         }
 
         [TestMethod]
@@ -65,9 +67,24 @@ namespace Alethic.Auth0.Operator.Tests
             var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10, MaxRequestDelay = TimeSpan.FromMinutes(1) }, time);
 
             // 10 requests left, 60 seconds until refill: pace at one request per 6 seconds
-            pacer.Record("tenant.us.auth0.com", Response(remaining: 10, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response(remaining: 10, resetEpochSeconds: 60));
 
-            Assert.AreEqual(TimeSpan.FromSeconds(6), pacer.GetDelay("tenant.us.auth0.com"));
+            Assert.AreEqual(TimeSpan.FromSeconds(6), pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
+        }
+
+        [TestMethod]
+        public void ConcurrentReservations_SerializeSends()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10, MaxRequestDelay = TimeSpan.FromMinutes(1) }, time);
+
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response(remaining: 10, resetEpochSeconds: 60));
+
+            // each reservation takes the next send slot instead of every caller sleeping the same 6 seconds
+            // and firing together
+            Assert.AreEqual(TimeSpan.FromSeconds(6), pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
+            Assert.AreEqual(TimeSpan.FromSeconds(12), pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
+            Assert.AreEqual(TimeSpan.FromSeconds(18), pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
         }
 
         [TestMethod]
@@ -77,9 +94,9 @@ namespace Alethic.Auth0.Operator.Tests
             var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10, MaxRequestDelay = TimeSpan.FromSeconds(10) }, time);
 
             // 0 remaining with a 60s reset would want a 60s delay; the cap bounds it
-            pacer.Record("tenant.us.auth0.com", Response(remaining: 0, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response(remaining: 0, resetEpochSeconds: 60));
 
-            Assert.AreEqual(TimeSpan.FromSeconds(10), pacer.GetDelay("tenant.us.auth0.com"));
+            Assert.AreEqual(TimeSpan.FromSeconds(10), pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
         }
 
         [TestMethod]
@@ -88,22 +105,22 @@ namespace Alethic.Auth0.Operator.Tests
             var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
             var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
 
-            pacer.Record("tenant.us.auth0.com", Response(remaining: 1, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response(remaining: 1, resetEpochSeconds: 60));
             time.Advance(TimeSpan.FromSeconds(61));
 
-            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+            Assert.AreEqual(TimeSpan.Zero, pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
         }
 
         [TestMethod]
-        public void BudgetIsPerHost()
+        public void WithoutLimitHeader_BudgetIsPerEndpoint()
         {
             var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
             var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
 
-            pacer.Record("a.us.auth0.com", Response(remaining: 1, resetEpochSeconds: 60));
+            pacer.Record("a.us.auth0.com GET /api/v2/clients", Response(remaining: 1, resetEpochSeconds: 60));
 
-            Assert.AreNotEqual(TimeSpan.Zero, pacer.GetDelay("a.us.auth0.com"));
-            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("b.us.auth0.com"));
+            Assert.AreNotEqual(TimeSpan.Zero, pacer.Reserve("a.us.auth0.com GET /api/v2/clients"));
+            Assert.AreEqual(TimeSpan.Zero, pacer.Reserve("b.us.auth0.com GET /api/v2/clients"));
         }
 
         [TestMethod]
@@ -112,11 +129,11 @@ namespace Alethic.Auth0.Operator.Tests
             var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
             var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
 
-            pacer.Record("tenant.us.auth0.com", Response(remaining: 1, resetEpochSeconds: 60));
-            pacer.Record("tenant.us.auth0.com", Response());
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response(remaining: 1, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response());
 
             // the headerless response must not clobber the recorded budget
-            Assert.AreNotEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+            Assert.AreNotEqual(TimeSpan.Zero, pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
         }
 
         [TestMethod]
@@ -125,10 +142,86 @@ namespace Alethic.Auth0.Operator.Tests
             var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
             var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10 }, time);
 
-            pacer.Record("tenant.us.auth0.com", Response(remaining: 1, resetEpochSeconds: 60));
-            pacer.Record("tenant.us.auth0.com", Response(remaining: 50, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response(remaining: 1, resetEpochSeconds: 60));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients", Response(remaining: 50, resetEpochSeconds: 60));
 
-            Assert.AreEqual(TimeSpan.Zero, pacer.GetDelay("tenant.us.auth0.com"));
+            Assert.AreEqual(TimeSpan.Zero, pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients"));
+        }
+
+        [TestMethod]
+        public void GenerousBucket_DoesNotMaskTightBucket()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10, MaxRequestDelay = TimeSpan.FromMinutes(1) }, time);
+
+            // the connection-reads bucket is nearly exhausted; a later response from the far more generous
+            // general bucket must not overwrite its budget and let connection reads flow unpaced
+            pacer.Record("tenant.us.auth0.com GET /api/v2/connections/*/clients", Response(remaining: 1, resetEpochSeconds: 60, limit: 50));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients/*", Response(remaining: 900, resetEpochSeconds: 60, limit: 1000));
+
+            Assert.AreNotEqual(TimeSpan.Zero, pacer.Reserve("tenant.us.auth0.com GET /api/v2/connections/*/clients"));
+            Assert.AreEqual(TimeSpan.Zero, pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients/*"));
+        }
+
+        [TestMethod]
+        public void EndpointsReportingSameLimit_ShareOneBucket()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10, MaxRequestDelay = TimeSpan.FromMinutes(2) }, time);
+
+            // two endpoint families reporting the same limit are one server-side bucket (e.g. the free tier's
+            // single Management API bucket); their sends must serialize against one shared budget, not each
+            // pace to the full refill rate independently
+            pacer.Record("tenant.us.auth0.com GET /api/v2/clients/*", Response(remaining: 2, resetEpochSeconds: 60, limit: 2));
+            pacer.Record("tenant.us.auth0.com GET /api/v2/client-grants", Response(remaining: 2, resetEpochSeconds: 60, limit: 2));
+
+            Assert.AreEqual(TimeSpan.FromSeconds(30), pacer.Reserve("tenant.us.auth0.com GET /api/v2/clients/*"));
+            Assert.AreEqual(TimeSpan.FromSeconds(60), pacer.Reserve("tenant.us.auth0.com GET /api/v2/client-grants"));
+        }
+
+        [TestMethod]
+        public void SameLimitOnDifferentHosts_SeparateBuckets()
+        {
+            var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+            var pacer = new Auth0RatePacer(new PacingOptions { RemainingThreshold = 10, MaxRequestDelay = TimeSpan.FromMinutes(2) }, time);
+
+            pacer.Record("a.us.auth0.com GET /api/v2/clients", Response(remaining: 2, resetEpochSeconds: 60, limit: 2));
+            pacer.Record("b.us.auth0.com GET /api/v2/clients", Response(remaining: 2, resetEpochSeconds: 60, limit: 2));
+
+            // tenants never share budgets, even when their buckets report the same limit
+            Assert.AreEqual(TimeSpan.FromSeconds(30), pacer.Reserve("a.us.auth0.com GET /api/v2/clients"));
+            Assert.AreEqual(TimeSpan.FromSeconds(30), pacer.Reserve("b.us.auth0.com GET /api/v2/clients"));
+        }
+
+        [TestMethod]
+        public void EndpointKeyFor_ReplacesIdSegments()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://tenant.us.auth0.com/api/v2/connections/con_AbC123/clients");
+            Assert.AreEqual("tenant.us.auth0.com GET /api/v2/connections/*/clients", Auth0RatePacer.EndpointKeyFor(request));
+        }
+
+        [TestMethod]
+        public void EndpointKeyFor_ReplacesUnprefixedIdSegments()
+        {
+            // client ids carry no prefix but always contain uppercase characters
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://tenant.us.auth0.com/api/v2/clients/HqT2mXWuRfg1KVXwLutM");
+            Assert.AreEqual("tenant.us.auth0.com GET /api/v2/clients/*", Auth0RatePacer.EndpointKeyFor(request));
+        }
+
+        [TestMethod]
+        public void EndpointKeyFor_KeepsRouteVocabulary()
+        {
+            // lowercase segments, hyphens and the version segment are route vocabulary, not ids
+            var request = new HttpRequestMessage(HttpMethod.Patch, "https://tenant.us.auth0.com/api/v2/email-templates/verify");
+            Assert.AreEqual("tenant.us.auth0.com PATCH /api/v2/email-templates/verify", Auth0RatePacer.EndpointKeyFor(request));
+        }
+
+        [TestMethod]
+        public void EndpointKeyFor_DistinguishesMethods()
+        {
+            var get = new HttpRequestMessage(HttpMethod.Get, "https://tenant.us.auth0.com/api/v2/clients");
+            var post = new HttpRequestMessage(HttpMethod.Post, "https://tenant.us.auth0.com/api/v2/clients");
+            Assert.AreNotEqual(Auth0RatePacer.EndpointKeyFor(get), Auth0RatePacer.EndpointKeyFor(post));
         }
 
     }

--- a/src/Alethic.Auth0.Operator.Tests/ConnectionEnabledClientsCacheTests.cs
+++ b/src/Alethic.Auth0.Operator.Tests/ConnectionEnabledClientsCacheTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Alethic.Auth0.Operator.Controllers;
+
+using Auth0.ManagementApi;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Alethic.Auth0.Operator.Tests
+{
+
+    /// <summary>
+    /// Coverage for the enabled-clients cache that keeps ConnectionClient reconciles from independently fetching
+    /// <c>GET /api/v2/connections/{id}/clients</c> — Auth0 places connection reads in a tightly limited rate limit
+    /// bucket, and the sweep-time fan-out of that call is what drained it. The tests run the real Management SDK
+    /// client over a counting handler so the response parsing contract is pinned too.
+    /// </summary>
+    [TestClass]
+    public class ConnectionEnabledClientsCacheTests
+    {
+
+        /// <summary>
+        /// Responds to enabled-clients GETs with a fixed client list and to enablement PATCHes with 204, counting
+        /// requests per method.
+        /// </summary>
+        sealed class CountingHandler : HttpMessageHandler
+        {
+
+            readonly string _body;
+
+            public CountingHandler(params string[] clientIds)
+            {
+                var items = new List<string>();
+                foreach (var clientId in clientIds)
+                    items.Add($"{{\"client_id\":\"{clientId}\"}}");
+
+                _body = $"{{\"clients\":[{string.Join(',', items)}],\"next\":null}}";
+            }
+
+            public int GetCount { get; private set; }
+
+            public int UpdateCount { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.Method == HttpMethod.Get)
+                {
+                    GetCount++;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_body, Encoding.UTF8, "application/json") });
+                }
+
+                UpdateCount++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+            }
+
+        }
+
+        static ManagementApiClient CreateClient(CountingHandler handler) =>
+            new ManagementApiClient("test-token", new ClientOptions
+            {
+                BaseUrl = "https://tenant.example.com/api/v2/",
+                HttpClient = new HttpClient(handler),
+                MaxRetries = 0,
+            });
+
+        [TestMethod]
+        public async Task RepeatedLookups_ShareOneFetchPerConnection()
+        {
+            var handler = new CountingHandler("client-a", "client-b");
+            var api = CreateClient(handler);
+            var cache = new ConnectionEnabledClientsCache(new MemoryCache(new MemoryCacheOptions()));
+
+            Assert.IsTrue(await cache.IsClientEnabledAsync(api, "con_1", "client-a", CancellationToken.None));
+            Assert.IsTrue(await cache.IsClientEnabledAsync(api, "con_1", "client-b", CancellationToken.None));
+            Assert.IsFalse(await cache.IsClientEnabledAsync(api, "con_1", "client-c", CancellationToken.None));
+
+            Assert.AreEqual(1, handler.GetCount, "every lookup for the same connection must be served by one fetch.");
+        }
+
+        [TestMethod]
+        public async Task SetClientEnabled_InvalidatesTheConnectionsEntry()
+        {
+            var handler = new CountingHandler("client-a");
+            var api = CreateClient(handler);
+            var cache = new ConnectionEnabledClientsCache(new MemoryCache(new MemoryCacheOptions()));
+
+            Assert.IsTrue(await cache.IsClientEnabledAsync(api, "con_1", "client-a", CancellationToken.None));
+            await cache.SetClientEnabledAsync(api, "con_1", "client-b", true, CancellationToken.None);
+            await cache.IsClientEnabledAsync(api, "con_1", "client-a", CancellationToken.None);
+
+            Assert.AreEqual(1, handler.UpdateCount);
+            Assert.AreEqual(2, handler.GetCount, "a write through the cache must invalidate the connection's entry so the next lookup refetches.");
+        }
+
+        [TestMethod]
+        public async Task DifferentConnections_FetchIndependently()
+        {
+            var handler = new CountingHandler("client-a");
+            var api = CreateClient(handler);
+            var cache = new ConnectionEnabledClientsCache(new MemoryCache(new MemoryCacheOptions()));
+
+            await cache.IsClientEnabledAsync(api, "con_1", "client-a", CancellationToken.None);
+            await cache.IsClientEnabledAsync(api, "con_2", "client-a", CancellationToken.None);
+
+            Assert.AreEqual(2, handler.GetCount);
+        }
+
+        [TestMethod]
+        public async Task DifferentApiClients_FetchIndependently()
+        {
+            // the api client instance is per tenant, so two tenants using the same connection id must not share
+            // an entry
+            var handlerA = new CountingHandler("client-a");
+            var handlerB = new CountingHandler("client-a");
+            var cache = new ConnectionEnabledClientsCache(new MemoryCache(new MemoryCacheOptions()));
+
+            await cache.IsClientEnabledAsync(CreateClient(handlerA), "con_1", "client-a", CancellationToken.None);
+            await cache.IsClientEnabledAsync(CreateClient(handlerB), "con_1", "client-a", CancellationToken.None);
+
+            Assert.AreEqual(1, handlerA.GetCount);
+            Assert.AreEqual(1, handlerB.GetCount);
+        }
+
+    }
+
+}

--- a/src/Alethic.Auth0.Operator/Controllers/ConnectionEnabledClientsCache.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/ConnectionEnabledClientsCache.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Connections;
+
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Alethic.Auth0.Operator.Controllers
+{
+
+    /// <summary>
+    /// Caches the set of client ids enabled on a connection. Many ConnectionClient resources typically share one
+    /// connection, and Auth0 places <c>GET /api/v2/connections/{id}/clients</c> in a tightly limited rate limit
+    /// bucket (connection reads allow as little as 50 requests/minute on self-service plans), so each reconcile
+    /// fetching the list independently drains the bucket during sweeps — one fetch per connection per TTL serves
+    /// them all instead. Entries are keyed by the management API client instance (itself cached per tenant for
+    /// the token lifetime) so tenants never share entries, and every write through
+    /// <see cref="SetClientEnabledAsync"/> invalidates the connection's entry so reconciles observe their own
+    /// writes immediately.
+    /// </summary>
+    public sealed class ConnectionEnabledClientsCache
+    {
+
+        sealed record CacheKey(IManagementApiClient Api, string ConnectionId);
+
+        /// <summary>
+        /// How long a fetched enabled-client set is served before it is refetched. Long enough to cover the
+        /// burst of ConnectionClient reconciles in a sweep, short enough that external drift is still observed
+        /// on the following sweep.
+        /// </summary>
+        static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(1);
+
+        readonly IMemoryCache _cache;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="cache"></param>
+        public ConnectionEnabledClientsCache(IMemoryCache cache)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        }
+
+        /// <summary>
+        /// Determines whether the given client is currently enabled on the given connection, serving the
+        /// connection's enabled-client set from cache when a fetch within the TTL already retrieved it.
+        /// </summary>
+        /// <param name="api"></param>
+        /// <param name="connectionId"></param>
+        /// <param name="clientId"></param>
+        /// <param name="cancellationToken"></param>
+        public async Task<bool> IsClientEnabledAsync(IManagementApiClient api, string connectionId, string clientId, CancellationToken cancellationToken)
+        {
+            var ids = await _cache.GetOrCreateAsync(new CacheKey(api, connectionId), async entry =>
+            {
+                entry.SetAbsoluteExpiration(CacheDuration);
+                return await GetEnabledClientIdsAsync(api, connectionId, cancellationToken);
+            });
+
+            return ids is not null && ids.Contains(clientId);
+        }
+
+        /// <summary>
+        /// Applies the given enablement status for a single client on a connection, and invalidates the cached
+        /// enabled-client set so subsequent reads observe the write.
+        /// </summary>
+        /// <param name="api"></param>
+        /// <param name="connectionId"></param>
+        /// <param name="clientId"></param>
+        /// <param name="status"></param>
+        /// <param name="cancellationToken"></param>
+        public async Task SetClientEnabledAsync(IManagementApiClient api, string connectionId, string clientId, bool status, CancellationToken cancellationToken)
+        {
+            var req = new List<UpdateEnabledClientConnectionsRequestContentItem>
+            {
+                new UpdateEnabledClientConnectionsRequestContentItem { ClientId = clientId, Status = status },
+            };
+
+            try
+            {
+                await api.Connections.Clients.UpdateAsync(connectionId, req, null, cancellationToken);
+            }
+            finally
+            {
+                _cache.Remove(new CacheKey(api, connectionId));
+            }
+        }
+
+        /// <summary>
+        /// Fetches the set of client ids enabled on the connection.
+        /// </summary>
+        /// <param name="api"></param>
+        /// <param name="connectionId"></param>
+        /// <param name="cancellationToken"></param>
+        static async Task<HashSet<string>> GetEnabledClientIdsAsync(IManagementApiClient api, string connectionId, CancellationToken cancellationToken)
+        {
+            var ids = new HashSet<string>();
+
+            var pager = await api.Connections.Clients.GetAsync(connectionId, new GetConnectionEnabledClientsRequestParameters(), null, cancellationToken);
+            if (pager?.CurrentPage?.Items is { } items)
+                foreach (var item in items)
+                    if (item.ClientId is { } id)
+                        ids.Add(id);
+
+            return ids;
+        }
+
+    }
+
+}

--- a/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionClientController.cs
+++ b/src/Alethic.Auth0.Operator/Controllers/V2alpha3ConnectionClientController.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,7 +9,6 @@ using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
 using Auth0.ManagementApi;
-using Auth0.ManagementApi.Connections;
 
 using k8s.Models;
 
@@ -43,17 +40,20 @@ namespace Alethic.Auth0.Operator.Controllers
         /// </summary>
         const char IdSeparator = '|';
 
+        readonly ConnectionEnabledClientsCache _enabledClients;
+
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="kube"></param>
         /// <param name="cache"></param>
+        /// <param name="enabledClients"></param>
         /// <param name="options"></param>
         /// <param name="logger"></param>
-        public V2alpha3ConnectionClientController(IKubernetesClient kube, IMemoryCache cache, IOptions<OperatorOptions> options, Auth0HttpClientProvider httpClientProvider, ILogger<V2alpha3ConnectionClientController> logger) :
+        public V2alpha3ConnectionClientController(IKubernetesClient kube, IMemoryCache cache, ConnectionEnabledClientsCache enabledClients, IOptions<OperatorOptions> options, Auth0HttpClientProvider httpClientProvider, ILogger<V2alpha3ConnectionClientController> logger) :
             base(kube, cache, options, httpClientProvider, logger)
         {
-
+            _enabledClients = enabledClients ?? throw new ArgumentNullException(nameof(enabledClients));
         }
 
         /// <inheritdoc />
@@ -85,17 +85,12 @@ namespace Alethic.Auth0.Operator.Controllers
         }
 
         /// <summary>
-        /// Determines whether the given client is currently enabled on the given connection.
+        /// Determines whether the given client is currently enabled on the given connection. Served through the
+        /// shared cache so ConnectionClient reconciles for the same connection share one Auth0 fetch per TTL.
         /// </summary>
-        async Task<bool> IsClientEnabledAsync(IManagementApiClient api, string connectionId, string clientId, CancellationToken cancellationToken)
+        Task<bool> IsClientEnabledAsync(IManagementApiClient api, string connectionId, string clientId, CancellationToken cancellationToken)
         {
-            var pager = await api.Connections.Clients.GetAsync(connectionId, new GetConnectionEnabledClientsRequestParameters(), null, cancellationToken);
-            if (pager?.CurrentPage?.Items is { } items)
-                foreach (var item in items)
-                    if (item.ClientId == clientId)
-                        return true;
-
-            return false;
+            return _enabledClients.IsClientEnabledAsync(api, connectionId, clientId, cancellationToken);
         }
 
         /// <summary>
@@ -103,12 +98,7 @@ namespace Alethic.Auth0.Operator.Controllers
         /// </summary>
         Task SetClientEnabledAsync(IManagementApiClient api, string connectionId, string clientId, bool status, CancellationToken cancellationToken)
         {
-            var req = new List<UpdateEnabledClientConnectionsRequestContentItem>
-            {
-                new UpdateEnabledClientConnectionsRequestContentItem { ClientId = clientId, Status = status },
-            };
-
-            return api.Connections.Clients.UpdateAsync(connectionId, req, null, cancellationToken);
+            return _enabledClients.SetClientEnabledAsync(api, connectionId, clientId, status, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Alethic.Auth0.Operator/Options/RateLimitOptions.cs
+++ b/src/Alethic.Auth0.Operator/Options/RateLimitOptions.cs
@@ -52,9 +52,10 @@ namespace Alethic.Auth0.Operator.Options
 
     /// <summary>
     /// Configuration for adaptive request pacing. Auth0 reports the remaining rate limit budget and its reset
-    /// time on every response; once the remaining budget falls to the threshold, outbound requests are delayed
-    /// so the rest of the budget is spread across the time until the reset — consumption slows to Auth0's
-    /// refill rate instead of draining the bucket.
+    /// time on every response, tracked per rate limit bucket (Auth0 enforces separate buckets for different
+    /// endpoint groups); once a bucket's remaining budget falls to the threshold, outbound requests to that
+    /// bucket's endpoints are delayed so the rest of the budget is spread across the time until the reset —
+    /// consumption slows to Auth0's refill rate instead of draining the bucket.
     /// </summary>
     public class PacingOptions
     {

--- a/src/Alethic.Auth0.Operator/Program.cs
+++ b/src/Alethic.Auth0.Operator/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 
+using Alethic.Auth0.Operator.Controllers;
 using Alethic.Auth0.Operator.Options;
 using Alethic.Auth0.Operator.RateLimiting;
 
@@ -30,6 +31,7 @@ namespace Alethic.Auth0.Operator
                 s.AutoAttachFinalizers = false;
             }).RegisterComponents();
             builder.Services.AddSingleton<Auth0HttpClientProvider>();
+            builder.Services.AddSingleton<ConnectionEnabledClientsCache>();
             builder.Services.AddMemoryCache();
             builder.Services.AddRouting();
             builder.Services.AddControllers();

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
@@ -10,9 +10,9 @@ namespace Alethic.Auth0.Operator.RateLimiting
 
     /// <summary>
     /// <see cref="DelegatingHandler"/> that gates every outgoing Auth0 Management API request through a rate limiter
-    /// before it is sent, paces requests down to Auth0's refill rate as the reported budget depletes, and trips the
-    /// per-domain circuit breaker on any 429 response so that no further requests reach that domain until the
-    /// server-reported rate limit reset.
+    /// before it is sent, paces requests down to Auth0's refill rate as the reported budget of the endpoint's rate
+    /// limit bucket depletes, and trips the per-domain circuit breaker on any 429 response so that no further
+    /// requests reach that domain until the server-reported rate limit reset.
     /// </summary>
     sealed class Auth0RateLimitingHandler : DelegatingHandler
     {
@@ -51,14 +51,21 @@ namespace Alethic.Auth0.Operator.RateLimiting
                     throw new HttpRequestException("Auth0 Management API client-side rate limit queue is full; backing off.");
             }
 
-            // when the reported budget is low, slow down to Auth0's refill rate instead of draining the bucket;
-            // holding the request (and thereby its reconcile slot) is the intended backpressure
-            if (_pacer?.GetDelay(host) is { } delay && delay > TimeSpan.Zero)
-                await Task.Delay(delay, cancellationToken);
+            // when the reported budget of the endpoint's rate limit bucket is low, reserve a send slot so
+            // consumption slows to Auth0's refill rate instead of draining the bucket; holding the request
+            // (and thereby its reconcile slot) is the intended backpressure
+            var endpoint = _pacer is null ? null : Auth0RatePacer.EndpointKeyFor(request);
+            if (endpoint is not null)
+            {
+                var delay = _pacer!.Reserve(endpoint);
+                if (delay > TimeSpan.Zero)
+                    await Task.Delay(delay, cancellationToken);
+            }
 
             var response = await base.SendAsync(request, cancellationToken);
 
-            _pacer?.Record(host, response);
+            if (endpoint is not null)
+                _pacer!.Record(endpoint, response);
 
             // a 429 opens the circuit for the whole domain; the response still flows back so the SDK surfaces
             // its rate limit error to the requesting reconcile, which reschedules on its own. a successful

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0RatePacer.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0RatePacer.cs
@@ -10,10 +10,16 @@ namespace Alethic.Auth0.Operator.RateLimiting
 {
 
     /// <summary>
-    /// Adaptive per-domain pacing of Auth0 Management API requests. Every response's rate limit headers are
-    /// recorded, and once the reported remaining budget falls to the configured threshold, outbound requests are
-    /// delayed just enough to spread the remaining budget across the time until the server-reported reset — so
-    /// consumption slows to Auth0's refill rate instead of draining the bucket and tripping the circuit breaker.
+    /// Adaptive pacing of Auth0 Management API requests, tracked per rate limit bucket. Auth0 enforces separate
+    /// token buckets for different endpoint groups (e.g. connection reads have a far smaller budget than the
+    /// general Management API on most plans), but no response header names the bucket — so the pacer learns the
+    /// mapping: each request is classified into an endpoint key (host + method + id-normalized path), and every
+    /// response binds that endpoint to a bucket fingerprinted by host and the reported <c>x-ratelimit-limit</c>.
+    /// Endpoints that report the same limit share one budget; endpoints with a dedicated bucket get their own,
+    /// so a generous bucket's headers can no longer mask an exhausted one. Once a bucket's remaining budget falls
+    /// to the configured threshold, sends are reserved serially — each caller takes the next send slot, spaced by
+    /// the time until reset divided by the remaining budget — so concurrent requests spread out to the refill
+    /// rate instead of sleeping identically and firing together.
     /// </summary>
     public sealed class Auth0RatePacer
     {
@@ -22,7 +28,10 @@ namespace Alethic.Auth0.Operator.RateLimiting
 
         readonly PacingOptions _options;
         readonly TimeProvider _time;
+        readonly ConcurrentDictionary<string, string> _buckets = new();
         readonly ConcurrentDictionary<string, Budget> _budgets = new();
+        readonly ConcurrentDictionary<string, DateTimeOffset> _nextSend = new();
+        readonly object _sync = new();
 
         /// <summary>
         /// Initializes a new instance.
@@ -36,12 +45,55 @@ namespace Alethic.Auth0.Operator.RateLimiting
         }
 
         /// <summary>
-        /// Records the rate limit budget reported by a response. Responses without both a parseable remaining
-        /// count and reset time are ignored.
+        /// Classifies a request into its endpoint key: host, method and path, with identifier segments (those
+        /// containing characters outside lowercase letters, digits and hyphens — Auth0 resource ids always do)
+        /// replaced by <c>*</c> so all requests against the same route template share one key.
         /// </summary>
-        /// <param name="host"></param>
+        /// <param name="request"></param>
+        public static string EndpointKeyFor(HttpRequestMessage request)
+        {
+            var host = request.RequestUri?.Host ?? string.Empty;
+            var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            return $"{host} {request.Method.Method} {NormalizePath(path)}";
+        }
+
+        /// <summary>
+        /// Replaces identifier path segments with <c>*</c>, keeping route vocabulary segments intact.
+        /// </summary>
+        /// <param name="path"></param>
+        internal static string NormalizePath(string path)
+        {
+            var segments = path.Split('/');
+            for (var i = 0; i < segments.Length; i++)
+                if (IsIdSegment(segments[i]))
+                    segments[i] = "*";
+
+            return string.Join('/', segments);
+        }
+
+        /// <summary>
+        /// An identifier segment contains at least one character outside lowercase letters, digits and hyphens.
+        /// Auth0 route vocabulary ("connections", "email-templates", "v2") is all lowercase, while resource ids
+        /// carry uppercase letters or underscores ("con_AbC123", client ids).
+        /// </summary>
+        /// <param name="segment"></param>
+        static bool IsIdSegment(string segment)
+        {
+            foreach (var c in segment)
+                if (char.IsAsciiLetterLower(c) == false && char.IsAsciiDigit(c) == false && c != '-')
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Records the rate limit budget reported by a response to the given endpoint, and binds the endpoint to
+        /// the bucket the response's <c>x-ratelimit-limit</c> fingerprints. Responses without both a parseable
+        /// remaining count and reset time are ignored; without a limit header the endpoint is its own bucket.
+        /// </summary>
+        /// <param name="endpoint"></param>
         /// <param name="response"></param>
-        public void Record(string host, HttpResponseMessage response)
+        public void Record(string endpoint, HttpResponseMessage response)
         {
             if (TryGetHeaderValue(response, "x-ratelimit-remaining", out var remaining) == false)
                 return;
@@ -49,32 +101,65 @@ namespace Alethic.Auth0.Operator.RateLimiting
             if (TryGetHeaderValue(response, "x-ratelimit-reset", out var resetEpochSeconds) == false)
                 return;
 
-            _budgets[host] = new Budget(remaining, DateTimeOffset.FromUnixTimeSeconds(resetEpochSeconds));
+            var bucket = TryGetHeaderValue(response, "x-ratelimit-limit", out var limit) ? BucketIdFor(endpoint, limit) : endpoint;
+
+            _buckets[endpoint] = bucket;
+            _budgets[bucket] = new Budget(remaining, DateTimeOffset.FromUnixTimeSeconds(resetEpochSeconds));
         }
 
         /// <summary>
-        /// Computes the delay to apply before the next request to <paramref name="host"/>: zero while the
-        /// reported budget is above the threshold or already reset, otherwise the time until reset divided by
-        /// the remaining budget, bounded by the configured maximum per-request delay.
+        /// Fingerprints a bucket by the endpoint's host and the reported limit, so endpoints of one tenant that
+        /// report the same limit share a budget while other tenants' buckets stay separate.
         /// </summary>
-        /// <param name="host"></param>
-        public TimeSpan GetDelay(string host)
+        /// <param name="endpoint"></param>
+        /// <param name="limit"></param>
+        static string BucketIdFor(string endpoint, long limit)
         {
-            if (_budgets.TryGetValue(host, out var budget) == false)
+            var i = endpoint.IndexOf(' ');
+            var host = i > 0 ? endpoint[..i] : endpoint;
+            return $"{host}#{limit}";
+        }
+
+        /// <summary>
+        /// Reserves a send slot for the next request to <paramref name="endpoint"/> and returns how long the
+        /// caller must wait before sending: zero while the endpoint's bucket is unknown, above the threshold or
+        /// already reset, otherwise the time until the reserved slot — slots are spaced by the time until reset
+        /// divided by the remaining budget, and each reservation pushes the bucket's next slot out, so concurrent
+        /// senders serialize instead of firing together. The returned delay is bounded by the configured maximum
+        /// per-request delay; beyond it, the circuit breaker is the backstop.
+        /// </summary>
+        /// <param name="endpoint"></param>
+        public TimeSpan Reserve(string endpoint)
+        {
+            if (_buckets.TryGetValue(endpoint, out var bucket) == false)
+                return TimeSpan.Zero;
+
+            if (_budgets.TryGetValue(bucket, out var budget) == false)
                 return TimeSpan.Zero;
 
             var now = _time.GetUtcNow();
             if (budget.Reset <= now)
             {
                 // the bucket has refilled; forget the stale budget unless a newer one raced in
-                _budgets.TryRemove(new System.Collections.Generic.KeyValuePair<string, Budget>(host, budget));
+                _budgets.TryRemove(new System.Collections.Generic.KeyValuePair<string, Budget>(bucket, budget));
                 return TimeSpan.Zero;
             }
 
             if (budget.Remaining > _options.RemainingThreshold)
                 return TimeSpan.Zero;
 
-            var delay = (budget.Reset - now) / Math.Max(budget.Remaining, 1);
+            var interval = (budget.Reset - now) / Math.Max(budget.Remaining, 1);
+            if (interval > _options.MaxRequestDelay)
+                interval = _options.MaxRequestDelay;
+
+            DateTimeOffset slot;
+            lock (_sync)
+            {
+                slot = _nextSend.TryGetValue(bucket, out var next) && next > now ? next + interval : now + interval;
+                _nextSend[bucket] = slot;
+            }
+
+            var delay = slot - now;
             if (delay > _options.MaxRequestDelay)
                 delay = _options.MaxRequestDelay;
 


### PR DESCRIPTION
## Problem

On operator startup (and periodic sweeps), Auth0 logs rate limit hits on `GET /api/v2/connections/{id}/clients`. Auth0 enforces separate rate limit buckets per endpoint group — connection reads allow as little as 50 requests/minute on self-service plans (and free tenants share a single 2 req/s bucket for the whole Management API) — but two things defeated the operator's rate limit machinery:

1. **Bucket masking.** The pacer tracked one budget per *domain*. A response from a generous bucket (e.g. client reads) overwrote the exhausted connections bucket's `x-ratelimit-remaining: 0`, so connection reads flowed unpaced until Auth0 returned real 429s.
2. **Fan-out.** Every ConnectionClient resource independently fetched its connection's enabled-client list each reconcile. A sweep of 38 ConnectionClients over 10 connections issued ~4x more connections-bucket reads than necessary, in a burst.

## Changes

- **Learned bucket fingerprinting.** No response header names the bucket, so the pacer learns the mapping: requests are classified into endpoint keys (host + method + id-normalized path), and each response binds its endpoint to a bucket fingerprinted by host + reported `x-ratelimit-limit`. Endpoints reporting the same limit share one budget (correct on free tenants where everything is one bucket); endpoints with a dedicated bucket get their own, so a generous bucket can no longer mask a tight one.
- **Serialized send slots.** Paced sends reserve consecutive slots per bucket, spaced at the refill rate, instead of every concurrent caller sleeping the same delay and firing together.
- **Shared enabled-clients cache.** `ConnectionEnabledClientsCache` serves the enabled-client set per connection for a 1-minute TTL, keyed by the per-tenant API client instance, invalidated on every enablement write so reconciles observe their own writes immediately. A sweep now costs one connections-bucket read per connection instead of one per ConnectionClient resource.

The per-domain circuit breaker is intentionally unchanged: it remains the conservative domain-wide backstop on any 429 or fully exhausted bucket.

## Testing

- New pacer tests: bucket fingerprint learning, masking regression (`GenerousBucket_DoesNotMaskTightBucket`), shared-bucket serialization, per-host isolation, endpoint key normalization.
- New cache tests run the real Management SDK client over a counting handler, pinning the wire contract (`{"clients":[{"client_id":...}]}`) alongside the caching behavior.
- Full suite: 407 passed.