### PR TITLE
Default the client-side rate limiter under Auth0's global bucket

### DIFF
--- a/src/Alethic.Auth0.Operator/Options/RateLimitOptions.cs
+++ b/src/Alethic.Auth0.Operator/Options/RateLimitOptions.cs
@@ -19,13 +19,19 @@ namespace Alethic.Auth0.Operator.Options
 
         /// <summary>
         /// Maximum burst capacity: the number of requests that may be issued immediately before throttling applies.
+        /// Auth0 also enforces a tenant-wide global bucket across all Management API endpoints combined that is as
+        /// small as 10 requests of burst on self-service plans — and unlike the per-endpoint buckets it is never
+        /// reported in response headers, so adaptive pacing cannot see it depleting. The burst must therefore sit
+        /// well below 10, leaving headroom for the dashboard and other API consumers on the tenant.
         /// </summary>
-        public int TokenLimit { get; set; } = 10;
+        public int TokenLimit { get; set; } = 5;
 
         /// <summary>
         /// Number of request tokens replenished each <see cref="ReplenishmentPeriod"/> (i.e. the sustained rate).
+        /// The default of 2/second (120/minute) stays under the global bucket's sustained refill of 150/minute
+        /// observed on self-service plans; raise it via configuration for tenants on plans with higher limits.
         /// </summary>
-        public int TokensPerPeriod { get; set; } = 5;
+        public int TokensPerPeriod { get; set; } = 2;
 
         /// <summary>
         /// How often <see cref="TokensPerPeriod"/> tokens are added back to the bucket.


### PR DESCRIPTION
## Problem

Verification of #32 in labs showed the remaining source of `api_limit` events: Auth0 enforces a tenant-wide **global** bucket across all Management API endpoints combined (`{"limit": {"size": 10, "global": true}}` in the tenant log events; 150/minute sustained on self-service plans). Unlike the per-endpoint buckets, the global bucket is **never reported in response headers** — a read can report `x-ratelimit-limit: 1000, remaining: 986` from its endpoint bucket while the size-10 global bucket is empty — so the adaptive pacer cannot see it depleting.

The client-side token bucket defaulted to burst 10 at 5/second: the cold-sweep burst of 10 alone empties Auth0's size-10 global bucket instantly whenever pacer budgets have gone stale, producing one `api_limit` event per sweep.

## Change

Default `TokenLimit` 10 → 5 and `TokensPerPeriod` 5 → 2 (120/minute, under the 150/minute global refill), with doc comments explaining the invisible global bucket. The operator alone can now never drain the global bucket, and headroom remains for the dashboard and other API consumers. Tenants on plans with higher limits can raise both via `Auth0__Operator__RateLimit__*` configuration.

## Testing

Full suite: 407 passed. Empirical bucket numbers taken from `api_limit` events and response headers on the labs tenants.