### PR TITLE
Add debug logging for Auth0 rate limit budgets, pacing and circuit state

### DIFF
--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0CircuitBreaker.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0CircuitBreaker.cs
@@ -6,6 +6,8 @@ using System.Net.Http;
 
 using Alethic.Auth0.Operator.Options;
 
+using Microsoft.Extensions.Logging;
+
 namespace Alethic.Auth0.Operator.RateLimiting
 {
 
@@ -20,6 +22,7 @@ namespace Alethic.Auth0.Operator.RateLimiting
 
         readonly CircuitBreakerOptions _options;
         readonly TimeProvider _time;
+        readonly ILogger? _logger;
         readonly ConcurrentDictionary<string, DateTimeOffset> _openUntil = new();
 
         /// <summary>
@@ -27,10 +30,12 @@ namespace Alethic.Auth0.Operator.RateLimiting
         /// </summary>
         /// <param name="options"></param>
         /// <param name="time"></param>
-        public Auth0CircuitBreaker(CircuitBreakerOptions options, TimeProvider? time = null)
+        /// <param name="logger"></param>
+        public Auth0CircuitBreaker(CircuitBreakerOptions options, TimeProvider? time = null, ILogger? logger = null)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _time = time ?? TimeProvider.System;
+            _logger = logger;
         }
 
         /// <summary>
@@ -47,7 +52,8 @@ namespace Alethic.Auth0.Operator.RateLimiting
                 throw new Auth0CircuitOpenException(host, until);
 
             // expired; remove only if unchanged so a concurrent reopen is not lost
-            _openUntil.TryRemove(new System.Collections.Generic.KeyValuePair<string, DateTimeOffset>(host, until));
+            if (_openUntil.TryRemove(new System.Collections.Generic.KeyValuePair<string, DateTimeOffset>(host, until)))
+                _logger?.LogDebug("Auth0 rate limit circuit for {Host} closed.", host);
         }
 
         /// <summary>
@@ -57,7 +63,8 @@ namespace Alethic.Auth0.Operator.RateLimiting
         /// </summary>
         /// <param name="host"></param>
         /// <param name="response"></param>
-        public DateTimeOffset Open(string host, HttpResponseMessage response)
+        /// <param name="endpoint"></param>
+        public DateTimeOffset Open(string host, HttpResponseMessage response, string? endpoint = null)
         {
             var now = _time.GetUtcNow();
 
@@ -70,8 +77,17 @@ namespace Alethic.Auth0.Operator.RateLimiting
             if (until > now + _options.MaxOpenDuration)
                 until = now + _options.MaxOpenDuration;
 
+            var wasOpen = _openUntil.TryGetValue(host, out var open) && open > now;
+
             // an already-open circuit is never shortened; return whichever deadline is now in effect
-            return _openUntil.AddOrUpdate(host, until, (_, existing) => until > existing ? until : existing);
+            var effective = _openUntil.AddOrUpdate(host, until, (_, existing) => until > existing ? until : existing);
+
+            if (wasOpen == false)
+                _logger?.LogWarning("Auth0 rate limit circuit for {Host} opened until {OpenUntil:O}: received 429 on {Endpoint}.", host, effective, endpoint);
+            else
+                _logger?.LogDebug("Auth0 rate limit circuit for {Host} extended until {OpenUntil:O}: received 429 on {Endpoint}.", host, effective, endpoint);
+
+            return effective;
         }
 
         /// <summary>
@@ -82,7 +98,8 @@ namespace Alethic.Auth0.Operator.RateLimiting
         /// </summary>
         /// <param name="host"></param>
         /// <param name="response"></param>
-        public DateTimeOffset? OpenIfExhausted(string host, HttpResponseMessage response)
+        /// <param name="endpoint"></param>
+        public DateTimeOffset? OpenIfExhausted(string host, HttpResponseMessage response, string? endpoint = null)
         {
             if (response.Headers.TryGetValues("x-ratelimit-remaining", out var remainingValues) == false)
                 return null;
@@ -99,7 +116,16 @@ namespace Alethic.Auth0.Operator.RateLimiting
             if (until > now + _options.MaxOpenDuration)
                 until = now + _options.MaxOpenDuration;
 
-            return _openUntil.AddOrUpdate(host, until.Value, (_, existing) => until.Value > existing ? until.Value : existing);
+            var wasOpen = _openUntil.TryGetValue(host, out var open) && open > now;
+
+            var effective = _openUntil.AddOrUpdate(host, until.Value, (_, existing) => until.Value > existing ? until.Value : existing);
+
+            if (wasOpen == false)
+                _logger?.LogWarning("Auth0 rate limit circuit for {Host} opened until {OpenUntil:O}: {Endpoint} reported its budget exhausted.", host, effective, endpoint);
+            else
+                _logger?.LogDebug("Auth0 rate limit circuit for {Host} extended until {OpenUntil:O}: {Endpoint} reported its budget exhausted.", host, effective, endpoint);
+
+            return effective;
         }
 
         /// <summary>

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0HttpClientProvider.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0HttpClientProvider.cs
@@ -3,6 +3,7 @@ using System.Threading.RateLimiting;
 
 using Alethic.Auth0.Operator.Options;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Alethic.Auth0.Operator.RateLimiting
@@ -21,9 +22,10 @@ namespace Alethic.Auth0.Operator.RateLimiting
         /// Initializes a new instance.
         /// </summary>
         /// <param name="options"></param>
-        public Auth0HttpClientProvider(IOptions<OperatorOptions> options)
+        /// <param name="loggerFactory"></param>
+        public Auth0HttpClientProvider(IOptions<OperatorOptions> options, ILoggerFactory? loggerFactory = null)
         {
-            Client = Create(options.Value.RateLimit);
+            Client = Create(options.Value.RateLimit, loggerFactory);
         }
 
         /// <summary>
@@ -35,7 +37,8 @@ namespace Alethic.Auth0.Operator.RateLimiting
         /// Builds the <see cref="HttpClient"/>, applying the rate limiter and circuit breaker when enabled.
         /// </summary>
         /// <param name="options"></param>
-        static HttpClient Create(RateLimitOptions options)
+        /// <param name="loggerFactory"></param>
+        static HttpClient Create(RateLimitOptions options, ILoggerFactory? loggerFactory)
         {
             var transport = new SocketsHttpHandler();
 
@@ -52,8 +55,8 @@ namespace Alethic.Auth0.Operator.RateLimiting
                         AutoReplenishment = true,
                     }));
 
-            var breaker = options.CircuitBreaker.Enabled ? new Auth0CircuitBreaker(options.CircuitBreaker) : null;
-            var pacer = options.Pacing.Enabled ? new Auth0RatePacer(options.Pacing) : null;
+            var breaker = options.CircuitBreaker.Enabled ? new Auth0CircuitBreaker(options.CircuitBreaker, null, loggerFactory?.CreateLogger<Auth0CircuitBreaker>()) : null;
+            var pacer = options.Pacing.Enabled ? new Auth0RatePacer(options.Pacing, null, loggerFactory?.CreateLogger<Auth0RatePacer>()) : null;
 
             if (limiter is null && breaker is null && pacer is null)
                 return new HttpClient(transport);

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0RateLimitingHandler.cs
@@ -54,27 +54,26 @@ namespace Alethic.Auth0.Operator.RateLimiting
             // when the reported budget of the endpoint's rate limit bucket is low, reserve a send slot so
             // consumption slows to Auth0's refill rate instead of draining the bucket; holding the request
             // (and thereby its reconcile slot) is the intended backpressure
-            var endpoint = _pacer is null ? null : Auth0RatePacer.EndpointKeyFor(request);
-            if (endpoint is not null)
+            var endpoint = Auth0RatePacer.EndpointKeyFor(request);
+            if (_pacer is not null)
             {
-                var delay = _pacer!.Reserve(endpoint);
+                var delay = _pacer.Reserve(endpoint);
                 if (delay > TimeSpan.Zero)
                     await Task.Delay(delay, cancellationToken);
             }
 
             var response = await base.SendAsync(request, cancellationToken);
 
-            if (endpoint is not null)
-                _pacer!.Record(endpoint, response);
+            _pacer?.Record(endpoint, response);
 
             // a 429 opens the circuit for the whole domain; the response still flows back so the SDK surfaces
             // its rate limit error to the requesting reconcile, which reschedules on its own. a successful
             // response reporting the bucket as exhausted opens the circuit preemptively, so the 429 the next
             // request would receive never happens
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
-                _breaker?.Open(host, response);
+                _breaker?.Open(host, response, endpoint);
             else
-                _breaker?.OpenIfExhausted(host, response);
+                _breaker?.OpenIfExhausted(host, response, endpoint);
 
             return response;
         }

--- a/src/Alethic.Auth0.Operator/RateLimiting/Auth0RatePacer.cs
+++ b/src/Alethic.Auth0.Operator/RateLimiting/Auth0RatePacer.cs
@@ -6,6 +6,8 @@ using System.Net.Http;
 
 using Alethic.Auth0.Operator.Options;
 
+using Microsoft.Extensions.Logging;
+
 namespace Alethic.Auth0.Operator.RateLimiting
 {
 
@@ -28,6 +30,7 @@ namespace Alethic.Auth0.Operator.RateLimiting
 
         readonly PacingOptions _options;
         readonly TimeProvider _time;
+        readonly ILogger? _logger;
         readonly ConcurrentDictionary<string, string> _buckets = new();
         readonly ConcurrentDictionary<string, Budget> _budgets = new();
         readonly ConcurrentDictionary<string, DateTimeOffset> _nextSend = new();
@@ -38,10 +41,12 @@ namespace Alethic.Auth0.Operator.RateLimiting
         /// </summary>
         /// <param name="options"></param>
         /// <param name="time"></param>
-        public Auth0RatePacer(PacingOptions options, TimeProvider? time = null)
+        /// <param name="logger"></param>
+        public Auth0RatePacer(PacingOptions options, TimeProvider? time = null, ILogger? logger = null)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _time = time ?? TimeProvider.System;
+            _logger = logger;
         }
 
         /// <summary>
@@ -101,10 +106,18 @@ namespace Alethic.Auth0.Operator.RateLimiting
             if (TryGetHeaderValue(response, "x-ratelimit-reset", out var resetEpochSeconds) == false)
                 return;
 
-            var bucket = TryGetHeaderValue(response, "x-ratelimit-limit", out var limit) ? BucketIdFor(endpoint, limit) : endpoint;
+            var hasLimit = TryGetHeaderValue(response, "x-ratelimit-limit", out var limit);
+            var bucket = hasLimit ? BucketIdFor(endpoint, limit) : endpoint;
+
+            if (_buckets.TryGetValue(endpoint, out var previous) == false || previous != bucket)
+                _logger?.LogDebug("Auth0 endpoint {Endpoint} bound to rate limit bucket {Bucket} (limit {Limit}).", endpoint, bucket, hasLimit ? limit : (long?)null);
+
+            var reset = DateTimeOffset.FromUnixTimeSeconds(resetEpochSeconds);
 
             _buckets[endpoint] = bucket;
-            _budgets[bucket] = new Budget(remaining, DateTimeOffset.FromUnixTimeSeconds(resetEpochSeconds));
+            _budgets[bucket] = new Budget(remaining, reset);
+
+            _logger?.LogDebug("Auth0 rate limit bucket {Bucket} has {Remaining} of {Limit} remaining, reset at {Reset:O} (reported by {Endpoint}).", bucket, remaining, hasLimit ? limit : (long?)null, reset, endpoint);
         }
 
         /// <summary>
@@ -162,6 +175,9 @@ namespace Alethic.Auth0.Operator.RateLimiting
             var delay = slot - now;
             if (delay > _options.MaxRequestDelay)
                 delay = _options.MaxRequestDelay;
+
+            if (delay > TimeSpan.Zero)
+                _logger?.LogDebug("Pacing Auth0 request to {Endpoint}: waiting {DelayMs}ms for a send slot on bucket {Bucket} ({Remaining} remaining, reset at {Reset:O}).", endpoint, (long)delay.TotalMilliseconds, bucket, budget.Remaining, budget.Reset);
 
             return delay;
         }


### PR DESCRIPTION
## What

The rate limit machinery was silent — budgets, pacing delays, and circuit transitions were invisible from the operator log, so diagnosing rate limit behavior meant correlating operator symptoms against the Auth0 tenant log (as we did chasing the `api_limit` events).

- **Budget per response** (debug): bucket, remaining, limit, reset time, and which endpoint reported it.
- **Bucket bindings** (debug): logged when an endpoint is first bound to a bucket fingerprint or rebinds.
- **Pacing** (debug): each reserved send slot with its delay and the bucket state that produced it.
- **Circuit transitions**: warning when a circuit *newly* opens — the message now distinguishes "received 429 on {endpoint}" from "{endpoint} reported its budget exhausted" (preemptive), which the reconcile-level warnings could not tell apart — and debug when an open circuit is extended or closes.

All loggers are optional constructor parameters, so existing tests and callers are untouched; `Auth0HttpClientProvider` wires them from `ILoggerFactory`.

## Enabling

Per environment: `Logging__LogLevel__Alethic.Auth0.Operator.RateLimiting=Debug` (the chart's `operator.env` passthrough works for this). Circuit open/close warnings appear at default levels.

## Testing

Full suite: 440 passed.